### PR TITLE
:recycle: refactor: don't wrap graphql errors as internal server errors

### DIFF
--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -1,5 +1,5 @@
 /**
- * BaseError is the base class for all errors in the application.
+ * KnownDomainError is the base class for all errors in the application.
  * It is used to provide a consistent way to handle errors in the application.
  * It is also used to provide a consistent way to handle errors in the client.
  *
@@ -7,7 +7,7 @@
  * @param description - Human-readable description of the error, e.g. "The email address is invalid"
  * @param code - A code that can be used to identify the error, e.g. "BAD_USER_INPUT", should be one of `codes`
  */
-export class BaseError extends Error {
+export class KnownDomainError extends Error {
   constructor(
     name: string,
     public description: string,
@@ -19,37 +19,37 @@ export class BaseError extends Error {
   }
 }
 
-export class InvalidArgumentError extends BaseError {
+export class InvalidArgumentError extends KnownDomainError {
   constructor(description: string) {
     super("InvalidArgumentError", description, errorCodes.ERR_BAD_USER_INPUT);
   }
 }
 
-export class InternalServerError extends BaseError {
+export class InternalServerError extends KnownDomainError {
   constructor(description: string) {
     super("InternalServerError", description, errorCodes.ERR_INTERNAL_SERVER_ERROR);
   }
 }
 
-export class PermissionDeniedError extends BaseError {
+export class PermissionDeniedError extends KnownDomainError {
   constructor(description: string) {
     super("PermissionDeniedError", description, errorCodes.ERR_PERMISSION_DENIED);
   }
 }
 
-export class AuthenticationError extends BaseError {
+export class AuthenticationError extends KnownDomainError {
   constructor(description: string) {
     super("AuthenticationError", description, errorCodes.ERR_PERMISSION_DENIED);
   }
 }
 
-export class NotFoundError extends BaseError {
+export class NotFoundError extends KnownDomainError {
   constructor(description: string) {
     super("NotFoundError", description, errorCodes.ERR_NOT_FOUND);
   }
 }
 
-export class BadRequestError extends BaseError {
+export class BadRequestError extends KnownDomainError {
   constructor(description: string) {
     super("BadRequestError", description, errorCodes.ERR_BAD_REQUEST);
   }
@@ -89,3 +89,22 @@ export const errorCodes = {
 } as const;
 
 export type ErrorCode = (typeof errorCodes)[keyof typeof errorCodes];
+
+const USER_FACING_ERRORS = new Set<string>([
+  errorCodes.ERR_BAD_REQUEST,
+  errorCodes.ERR_BAD_USER_INPUT,
+  errorCodes.ERR_PERMISSION_DENIED,
+  errorCodes.ERR_NOT_FOUND,
+]);
+
+function isErrorWithCode(error: Error | undefined): error is Error & { code: string } {
+  if (!error) return false;
+  return "code" in error;
+}
+
+export function isUserFacingError(error?: Error): boolean {
+  if (isErrorWithCode(error)) {
+    return USER_FACING_ERRORS.has(error.code);
+  }
+  return false;
+}

--- a/src/domain/events.ts
+++ b/src/domain/events.ts
@@ -1,6 +1,6 @@
-import { BaseError, errorCodes } from "./errors.js";
+import { KnownDomainError, errorCodes } from "./errors.js";
 
-export class AlreadySignedUpError extends BaseError {
+export class AlreadySignedUpError extends KnownDomainError {
   constructor(description: string) {
     super("AlreadySignedUpError", description, errorCodes.ERR_BAD_USER_INPUT);
   }

--- a/src/graphql/test-clients/mock-apollo-server.ts
+++ b/src/graphql/test-clients/mock-apollo-server.ts
@@ -68,6 +68,7 @@ export const createMockApolloServer = (logger?: Partial<FastifyBaseLogger>) => {
     typeDefs: typeDefs,
     resolvers: resolvers,
     formatError: getFormatErrorHandler(logger),
+    includeStacktraceInErrorResponses: true,
   });
 
   const userService = mockDeep<ApolloContext["userService"]>();

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,28 +1,9 @@
 import { ApolloServerPlugin } from "@apollo/server";
 import { FastifyInstance } from "fastify";
 
-import { errorCodes } from "@/domain/errors.js";
+import { isUserFacingError } from "@/domain/errors.js";
 
 import { ApolloContext } from "./apollo-server.js";
-
-const USER_FACING_ERRORS = new Set<string>([
-  errorCodes.ERR_BAD_REQUEST,
-  errorCodes.ERR_BAD_USER_INPUT,
-  errorCodes.ERR_PERMISSION_DENIED,
-  errorCodes.ERR_NOT_FOUND,
-]);
-
-function isErrorWithCode(error: Error | undefined): error is Error & { code: string } {
-  if (!error) return false;
-  return "code" in error;
-}
-
-function isUserFacingError(error?: Error): boolean {
-  if (isErrorWithCode(error)) {
-    return USER_FACING_ERRORS.has(error.code);
-  }
-  return false;
-}
 
 /**
  * Plugin for Apollo Server that reports errors to Sentry.

--- a/src/server.ts
+++ b/src/server.ts
@@ -177,6 +177,7 @@ export async function initServer(dependencies: ServerDependencies, opts: Options
     introspection: true,
     resolvers: resolvers,
     formatError: getFormatErrorHandler(app.log.child({ service: "apollo-server" })),
+    includeStacktraceInErrorResponses: env.NODE_ENV !== "production",
     plugins: [
       fastifyApolloDrainPlugin(app),
       fastifyApolloSentryPlugin(app),

--- a/src/services/events/__tests__/unit/events.test.ts
+++ b/src/services/events/__tests__/unit/events.test.ts
@@ -3,7 +3,7 @@ import { Event } from "@prisma/client";
 import { mockDeep } from "jest-mock-extended";
 import { DateTime } from "luxon";
 
-import { BaseError, InvalidArgumentError, PermissionDeniedError } from "@/domain/errors.js";
+import { KnownDomainError, InvalidArgumentError, PermissionDeniedError } from "@/domain/errors.js";
 import { Role } from "@/domain/organizations.js";
 
 import { EventRepository, EventService, PermissionService } from "../../service.js";
@@ -53,7 +53,7 @@ describe("EventsService", () => {
             slots?: { capacity: number }[];
           };
         };
-        expectedError: typeof BaseError;
+        expectedError: typeof KnownDomainError;
       }
 
       const testCases: TestCase[] = [
@@ -281,7 +281,7 @@ describe("EventsService", () => {
           };
         };
         assert: {
-          error: typeof BaseError;
+          error: typeof KnownDomainError;
         };
       }
       const startAt = faker.date.soon();

--- a/src/services/organizations/__tests__/integration/organizations.test.ts
+++ b/src/services/organizations/__tests__/integration/organizations.test.ts
@@ -3,7 +3,7 @@ import assert from "assert";
 import { faker } from "@faker-js/faker";
 import { Prisma } from "@prisma/client";
 
-import { BaseError, InvalidArgumentError, PermissionDeniedError } from "@/domain/errors.js";
+import { KnownDomainError, InvalidArgumentError, PermissionDeniedError } from "@/domain/errors.js";
 import { Role } from "@/domain/organizations.js";
 import prisma from "@/lib/prisma.js";
 import { MemberRepository } from "@/repositories/organizations/members.js";
@@ -271,7 +271,7 @@ describe("OrganizationsService", () => {
         act: {
           memberIndex: number;
         };
-        expected: typeof BaseError;
+        expected: typeof KnownDomainError;
       }
 
       const selfId = faker.string.uuid();

--- a/src/services/organizations/__tests__/unit/organizations.test.ts
+++ b/src/services/organizations/__tests__/unit/organizations.test.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import type { Member, Organization } from "@prisma/client";
 import { DeepMockProxy, mock, mockDeep } from "jest-mock-extended";
 
-import { BaseError, InvalidArgumentError, PermissionDeniedError } from "@/domain/errors.js";
+import { KnownDomainError, InvalidArgumentError, PermissionDeniedError } from "@/domain/errors.js";
 import { Role } from "@/domain/organizations.js";
 import { User } from "@/domain/users.js";
 import { UserRepository } from "@/repositories/users/index.js";
@@ -140,7 +140,7 @@ describe("OrganizationService", () => {
           name?: string;
           description?: string;
         };
-        expectedError: typeof BaseError;
+        expectedError: typeof KnownDomainError;
       }[] = [
         {
           name: "if the user is not a member of the organization",
@@ -313,7 +313,7 @@ describe("OrganizationService", () => {
           name: string;
           description?: string;
         };
-        expectedError: typeof BaseError;
+        expectedError: typeof KnownDomainError;
       }[] = [
         {
           name: "if the description is too long",
@@ -484,7 +484,7 @@ describe("OrganizationService", () => {
           userId: string;
           role: Role;
         };
-        expectedError: typeof BaseError;
+        expectedError: typeof KnownDomainError;
       }
       const testCases: TestCase[] = [
         {
@@ -554,7 +554,7 @@ describe("OrganizationService", () => {
           organizationId: string;
           userId: string;
         };
-        expectedError: typeof BaseError;
+        expectedError: typeof KnownDomainError;
       }
       const testCases: TestCase[] = [
         {


### PR DESCRIPTION
### Changes
- Malformed GraphQL requests are not Internal Server Errors :)