### PR TITLE
:sparkles: feat: add `canSignUp` event resolver

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -187,6 +187,12 @@ type DeleteListingResponse {
 
 type Event {
   """
+  canSignUp is true if the current user can sign up for the event, false otherwise.
+  If the user is not logged in, this will be always be false.
+  """
+  canSignUp: Boolean!
+
+  """
   The description of the event. We support markdown on the client, so this can be markdown.
   """
   description: String!

--- a/src/graphql/events/resolvers/Event.ts
+++ b/src/graphql/events/resolvers/Event.ts
@@ -1,4 +1,17 @@
+import { AuthenticationError } from "@/domain/errors.js";
+import { assertIsAuthenticated } from "@/graphql/auth.js";
+
 import type { EventResolvers } from "./../../types.generated.js";
 export const Event: EventResolvers = {
   /* Implement Event resolver logic here */
+  canSignUp: (parent, _args, ctx) => {
+    try {
+      assertIsAuthenticated(ctx);
+      const canSignUp = ctx.eventService.canSignUpForEvent(ctx.req.session.userId, parent.id);
+      return canSignUp;
+    } catch (err) {
+      if (err instanceof AuthenticationError) return false;
+      throw err;
+    }
+  },
 };

--- a/src/graphql/events/schema.graphql
+++ b/src/graphql/events/schema.graphql
@@ -16,6 +16,11 @@ type Event {
   The end time of the event.
   """
   endAt: DateTime!
+  """
+  canSignUp is true if the current user can sign up for the event, false otherwise.
+  If the user is not logged in, this will be always be false.
+  """
+  canSignUp: Boolean!
 }
 
 type EventsResponse {

--- a/src/lib/apollo-server.ts
+++ b/src/lib/apollo-server.ts
@@ -171,6 +171,7 @@ interface IEventService {
   findMany(data?: { onlyFutureEvents?: boolean | null }): Promise<Event[]>;
   signUp(userId: string, eventId: string): Promise<EventSignUp>;
   retractSignUp(userId: string, eventId: string): Promise<EventSignUp>;
+  canSignUpForEvent(userId: string, eventId: string): Promise<boolean>;
 }
 
 interface ListingService {

--- a/src/services/auth/__tests__/integration/authentication.test.ts
+++ b/src/services/auth/__tests__/integration/authentication.test.ts
@@ -6,6 +6,8 @@ import { defaultTestDependenciesFactory } from "@/__tests__/dependencies-factory
 import { AuthenticationError } from "@/domain/errors.js";
 import { User } from "@/domain/users.js";
 
+import { jest } from "@jest/globals";
+import { DateTime } from "luxon";
 import { AuthClient } from "../../clients.js";
 import { FeideProvider } from "../../providers.js";
 import { AuthService, UserService } from "../../service.js";
@@ -14,6 +16,13 @@ describe("AuthService", () => {
   let authService: AuthService;
   let feideClient: DeepMockProxy<AuthClient>;
   let userService: UserService;
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   beforeAll(() => {
     feideClient = mock<AuthClient>();
@@ -152,6 +161,8 @@ describe("AuthService", () => {
         feideId: faker.string.uuid(),
         username: faker.string.sample(),
       });
+
+      jest.setSystemTime(DateTime.now().plus({ minutes: 5 }).toJSDate());
       const req = mockDeep<FastifyRequest>();
       const actual = await authService.login(
         req,

--- a/src/services/auth/__tests__/integration/authentication.test.ts
+++ b/src/services/auth/__tests__/integration/authentication.test.ts
@@ -1,13 +1,13 @@
 import { faker } from "@faker-js/faker";
+import { jest } from "@jest/globals";
 import { FastifyRequest } from "fastify";
 import { DeepMockProxy, mock, mockDeep } from "jest-mock-extended";
+import { DateTime } from "luxon";
 
 import { defaultTestDependenciesFactory } from "@/__tests__/dependencies-factory.js";
 import { AuthenticationError } from "@/domain/errors.js";
 import { User } from "@/domain/users.js";
 
-import { jest } from "@jest/globals";
-import { DateTime } from "luxon";
 import { AuthClient } from "../../clients.js";
 import { FeideProvider } from "../../providers.js";
 import { AuthService, UserService } from "../../service.js";


### PR DESCRIPTION
### Changes
- Add `canSignUp` event resolver, which is `true` whenever the current user can sign up for the event.
- Add unit tests for the aforementioned resolver
- Fix a flaky login test by using jest to manipulate time 🪄