### PR TITLE
:sparkles: feat(permissions): add hasFeaturePermission to gql

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -262,6 +262,15 @@ enum FeaturePermission {
   CABIN_BOOKING
 }
 
+input HasFeaturePermissionInput {
+  featurePermission: FeaturePermission!
+}
+
+type HasFeaturePermissionResponse {
+  hasFeaturePermission: Boolean!
+  id: FeaturePermission!
+}
+
 type Listing {
   """
   An optional URL to the application form for the listing, defaults to ""
@@ -527,6 +536,7 @@ type Query {
   cabins: CabinsResponse!
   event(data: EventInput!): EventResponse!
   events(data: EventsInput): EventsResponse!
+  hasFeaturePermission(data: HasFeaturePermissionInput!): HasFeaturePermissionResponse!
   listing(data: ListingInput!): ListingResponse!
   listings: ListingsResponse!
 

--- a/src/graphql/__tests__/integration/authentication.test.ts
+++ b/src/graphql/__tests__/integration/authentication.test.ts
@@ -1,0 +1,82 @@
+import { faker } from "@faker-js/faker";
+import { DeepMockProxy, mock, mockDeep, mockFn } from "jest-mock-extended";
+
+import { NotFoundError } from "@/domain/errors.js";
+import { User } from "@/domain/users.js";
+import { GraphQLTestClient, newGraphQLTestClient } from "@/graphql/test-clients/graphql-test-client.js";
+import { graphql } from "@/graphql/test-clients/integration/gql.js";
+import { UserService } from "@/services/users/service.js";
+
+describe("Apollo Context Authentication", () => {
+  let client: GraphQLTestClient;
+  let mockUserService: DeepMockProxy<UserService>;
+
+  afterAll(async () => {
+    await client.app.close();
+  });
+
+  beforeAll(async () => {
+    mockUserService = mockDeep<UserService>();
+    client = await newGraphQLTestClient({ port: 4389 }, { apolloServerDependencies: { userService: mockUserService } });
+  });
+
+  it("should set ctx.user if a user with the userId in session exists", async () => {
+    const userId = faker.string.uuid();
+    // The query will log the user in, and in doing so, it will call mockUserService.create to create the user.
+    mockUserService.get.mockResolvedValue(mock<User>({ id: userId }));
+    mockUserService.create.mockResolvedValue(mock<User>({ id: userId }));
+
+    const { errors } = await client.query(
+      {
+        query: graphql(`
+          query AuthContext {
+            user {
+              user {
+                id
+              }
+            }
+          }
+        `),
+      },
+      { user: { feideId: userId } }
+    );
+
+    expect(errors).toBeUndefined();
+    expect(mockUserService.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call log out on the request if the user in the session does not exist", async () => {
+    const userId = faker.string.uuid();
+    // The query will log the user in, and in doing so, it will call mockUserService.create to create the user.
+    mockUserService.get.mockImplementationOnce(() => {
+      throw new NotFoundError("User not found");
+    });
+    mockUserService.create.mockResolvedValue(mock<User>({ id: userId }));
+    // We mock the logout function so we can montior that it is called
+    client.dependencies.authService.logout = mockFn();
+
+    const { errors, data } = await client.query(
+      {
+        query: graphql(`
+          query AuthContext {
+            user {
+              user {
+                id
+              }
+            }
+          }
+        `),
+      },
+      { user: { feideId: userId } }
+    );
+
+    expect(errors).toBeUndefined();
+    expect(data?.user.user).toBeNull();
+    expect(mockUserService.get).toHaveBeenCalledTimes(1);
+    expect(client.dependencies.authService.logout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({ authenticated: true, userId }),
+      })
+    );
+  });
+});

--- a/src/graphql/auth.ts
+++ b/src/graphql/auth.ts
@@ -1,7 +1,8 @@
 import { AuthenticationError } from "@/domain/errors.js";
+import { User } from "@/domain/users.js";
 import { ApolloContext } from "@/lib/apollo-server.js";
 
-type AuthenticatedContext = ApolloContext & { req: { session: { userId: string; authenticated: true } } };
+type AuthenticatedContext = ApolloContext & { req: { session: { userId: string; authenticated: true } }; user: User };
 
 /**
  * Assert that the user is authenticated
@@ -12,6 +13,6 @@ type AuthenticatedContext = ApolloContext & { req: { session: { userId: string; 
  */
 export function assertIsAuthenticated(ctx: ApolloContext): asserts ctx is AuthenticatedContext {
   const { authenticated, userId } = ctx.req.session;
-  if (authenticated && typeof userId === "string" && userId !== "") return;
+  if (authenticated && typeof userId === "string" && userId !== "" && ctx.user !== null) return;
   throw new AuthenticationError("You must be logged in to perform this action.");
 }

--- a/src/graphql/permissions/resolvers/HasFeaturePermissionResponse.ts
+++ b/src/graphql/permissions/resolvers/HasFeaturePermissionResponse.ts
@@ -1,0 +1,4 @@
+import type { HasFeaturePermissionResponseResolvers } from "./../../types.generated.js";
+export const HasFeaturePermissionResponse: HasFeaturePermissionResponseResolvers = {
+  /* Implement HasFeaturePermissionResponse resolver logic here */
+};

--- a/src/graphql/permissions/resolvers/Query/hasFeaturePermission.ts
+++ b/src/graphql/permissions/resolvers/Query/hasFeaturePermission.ts
@@ -1,0 +1,17 @@
+import { assertIsAuthenticated } from "@/graphql/auth.js";
+
+import type { QueryResolvers } from "./../../../types.generated.js";
+export const hasFeaturePermission: NonNullable<QueryResolvers["hasFeaturePermission"]> = async (
+  _parent,
+  { data },
+  ctx
+) => {
+  assertIsAuthenticated(ctx);
+
+  const hasFeaturePermission = await ctx.permissionService.hasFeaturePermission({
+    userId: ctx.user.id,
+    featurePermission: data.featurePermission,
+  });
+  ctx.req.log.info({ userId: ctx.user.id, featurePermission: data.featurePermission, hasFeaturePermission });
+  return { hasFeaturePermission, id: data.featurePermission };
+};

--- a/src/graphql/permissions/resolvers/Query/hasFeaturePermission.unit.test.ts
+++ b/src/graphql/permissions/resolvers/Query/hasFeaturePermission.unit.test.ts
@@ -1,0 +1,70 @@
+import { faker } from "@faker-js/faker";
+
+import { errorCodes } from "@/domain/errors.js";
+import { createMockApolloServer } from "@/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "@/graphql/test-clients/unit/gql.js";
+
+describe("Permission queries", () => {
+  describe("#hasFeaturePermission", () => {
+    it("should raise PermissionDeniedError if the user is not authenticated", async () => {
+      const { client } = createMockApolloServer();
+
+      const { errors } = await client.query({
+        query: graphql(`
+          query UnauthenticatedHasPermission($data: HasFeaturePermissionInput!) {
+            hasFeaturePermission(data: $data) {
+              hasFeaturePermission
+              id
+            }
+          }
+        `),
+        variables: {
+          data: {
+            featurePermission: "CABIN_BOOKING",
+          },
+        },
+      });
+
+      expect(errors).toBeDefined();
+      expect(errors).toHaveLength(1);
+      expect(errors?.every((err) => err.extensions?.code === errorCodes.ERR_PERMISSION_DENIED)).toBe(true);
+    });
+
+    it("should call hasFeaturePermission with the correct parameters", async () => {
+      const { client, createMockContext, permissionService } = createMockApolloServer();
+      const authenticatedContext = createMockContext({
+        user: {
+          id: faker.string.uuid(),
+        },
+      });
+      permissionService.hasFeaturePermission.mockResolvedValueOnce(true);
+
+      const { errors } = await client.query(
+        {
+          query: graphql(`
+            query UnauthenticatedHasPermission($data: HasFeaturePermissionInput!) {
+              hasFeaturePermission(data: $data) {
+                hasFeaturePermission
+                id
+              }
+            }
+          `),
+          variables: {
+            data: {
+              featurePermission: "CABIN_BOOKING",
+            },
+          },
+        },
+        {
+          contextValue: authenticatedContext,
+        }
+      );
+
+      expect(errors).toBeUndefined();
+      expect(permissionService.hasFeaturePermission).toHaveBeenCalledWith({
+        userId: authenticatedContext.user?.id,
+        featurePermission: "CABIN_BOOKING",
+      });
+    });
+  });
+});

--- a/src/graphql/permissions/schema.graphql
+++ b/src/graphql/permissions/schema.graphql
@@ -1,0 +1,17 @@
+enum FeaturePermission {
+  CABIN_BOOKING
+  ARCHIVE
+}
+
+type HasFeaturePermissionResponse {
+  id: FeaturePermission!
+  hasFeaturePermission: Boolean!
+}
+
+input HasFeaturePermissionInput {
+  featurePermission: FeaturePermission!
+}
+
+type Query {
+  hasFeaturePermission(data: HasFeaturePermissionInput!): HasFeaturePermissionResponse!
+}

--- a/src/graphql/test-clients/graphql-test-client.ts
+++ b/src/graphql/test-clients/graphql-test-client.ts
@@ -1,3 +1,4 @@
+import { faker } from "@faker-js/faker";
 import { ResultOf, VariablesOf } from "@graphql-typed-document-node/core";
 import { PrismaClient } from "@prisma/client";
 import { FastifyInstance, InjectOptions, LightMyRequestResponse } from "fastify";
@@ -8,7 +9,6 @@ import { MockOpenIdClient, newMockOpenIdClient } from "@/__tests__/mocks/openIdC
 import { env } from "@/config.js";
 import { ApolloServerDependencies } from "@/lib/apollo-server.js";
 import { initServer } from "@/server.js";
-import { faker } from "@faker-js/faker";
 
 /**
  * A test client for integration testing GraphQL resolvers.

--- a/src/graphql/test-clients/graphql-test-client.ts
+++ b/src/graphql/test-clients/graphql-test-client.ts
@@ -8,6 +8,7 @@ import { MockOpenIdClient, newMockOpenIdClient } from "@/__tests__/mocks/openIdC
 import { env } from "@/config.js";
 import { ApolloServerDependencies } from "@/lib/apollo-server.js";
 import { initServer } from "@/server.js";
+import { faker } from "@faker-js/faker";
 
 /**
  * A test client for integration testing GraphQL resolvers.
@@ -63,12 +64,22 @@ export class GraphQLTestClient {
     this.mockOpenIdClient = options.mockOpenIdClient;
   }
 
-  public async performMockedLogin(userId: string): Promise<{ cookies: Record<string, string>; userId: string }> {
-    const user = await this.dependencies?.apolloServerDependencies.userService.get(userId);
+  public async performMockedLogin(
+    data: { userId: string } | { feideId: string; email?: string; name?: string }
+  ): Promise<{ cookies: Record<string, string>; userId: string }> {
+    if ("userId" in data) {
+      const user = await this.dependencies?.apolloServerDependencies.userService.get(data.userId);
+      this.mockOpenIdClient.updateUserResponseMock({
+        id: user.feideId,
+        email: user.email,
+        name: `${user.firstName} ${user.lastName}`,
+      });
+      return await this.performLogin();
+    }
     this.mockOpenIdClient.updateUserResponseMock({
-      id: user.feideId,
-      email: user.email,
-      name: `${user.firstName} ${user.lastName}`,
+      id: data.feideId,
+      email: data.email ?? faker.internet.email(),
+      name: data.name ?? faker.person.fullName(),
     });
     return await this.performLogin();
   }
@@ -136,6 +147,7 @@ export class GraphQLTestClient {
     },
     options?: {
       userId?: string;
+      user?: { feideId: string; email?: string; name?: string };
       request?: InjectOptions;
     }
   ): Promise<{
@@ -144,12 +156,16 @@ export class GraphQLTestClient {
     response: LightMyRequestResponse;
   }> {
     const { query, variables } = queryData;
-    const { request, userId } = options ?? {};
+    const { request, userId, user } = options ?? {};
     let cookies: Record<string, string> | undefined;
     if (userId) {
-      const res = await this.performMockedLogin(userId);
+      const res = await this.performMockedLogin({ userId });
       cookies = res.cookies;
       this.app.log.info("Logged in as user", { userId });
+    } else if (user) {
+      const res = await this.performMockedLogin(user);
+      cookies = res.cookies;
+      this.app.log.info("Logged in as user", { userId: user.feideId });
     }
 
     const response = await this.app.inject({

--- a/src/graphql/users/resolvers/Query/user.ts
+++ b/src/graphql/users/resolvers/Query/user.ts
@@ -1,13 +1,5 @@
 import type { QueryResolvers } from "./../../../types.generated.js";
 export const user: NonNullable<QueryResolvers["user"]> = async (_parent, _arg, ctx) => {
-  const { userId } = ctx.req.session;
-  if (userId) {
-    const user = await ctx.userService.get(userId);
-    return {
-      user: user,
-    };
-  }
-  return {
-    user: null,
-  };
+  const { user } = ctx;
+  return { user };
 };

--- a/src/lib/apollo-server.ts
+++ b/src/lib/apollo-server.ts
@@ -65,6 +65,7 @@ export function getFormatErrorHandler(log?: Partial<FastifyInstance["log"]>) {
 export interface ApolloContext extends ApolloServerDependencies {
   res: FastifyReply;
   req: FastifyRequest;
+  user: User | null;
 }
 
 declare module "graphql" {
@@ -223,4 +224,5 @@ export interface ApolloServerDependencies {
 
 interface IPermissionService {
   isSuperUser(userId: string): Promise<{ isSuperUser: boolean }>;
+  hasFeaturePermission(data: { userId: string; featurePermission: FeaturePermission }): Promise<boolean>;
 }

--- a/src/repositories/organizations/seed.ts
+++ b/src/repositories/organizations/seed.ts
@@ -52,6 +52,19 @@ export const load = async (db: PrismaClient) => {
     },
   });
 
+  await db.organization.upsert({
+    where: {
+      name: "Rubberdøk",
+    },
+    update: {
+      featurePermissions: [FeaturePermission.CABIN_BOOKING],
+    },
+    create: {
+      name: "Rubberdøk",
+      featurePermissions: [FeaturePermission.CABIN_BOOKING],
+    },
+  });
+
   const organizations = await db.organization.findMany({
     select: {
       name: true,

--- a/src/repositories/users/__tests__/integration/get.test.ts
+++ b/src/repositories/users/__tests__/integration/get.test.ts
@@ -1,0 +1,30 @@
+import { faker } from "@faker-js/faker";
+
+import { NotFoundError } from "@/domain/errors.js";
+import prisma from "@/lib/prisma.js";
+
+import { UserRepository } from "../../index.js";
+
+describe("UserRepository", () => {
+  let userRepository: UserRepository;
+
+  beforeAll(() => {
+    userRepository = new UserRepository(prisma);
+  });
+  describe("#get", () => {
+    it("should raise NotFoundError if user does not exist", async () => {
+      await expect(userRepository.get(faker.string.uuid())).rejects.toThrow(NotFoundError);
+    });
+
+    it("should return user if it exists", async () => {
+      const user = await userRepository.create({
+        username: faker.internet.exampleEmail({ firstName: faker.string.uuid() }),
+        email: faker.internet.email(),
+        feideId: faker.string.uuid(),
+        firstName: faker.person.firstName(),
+        lastName: faker.person.lastName(),
+      });
+      await expect(userRepository.get(user.id)).resolves.toEqual(user);
+    });
+  });
+});

--- a/src/repositories/users/seed.ts
+++ b/src/repositories/users/seed.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { Prisma, PrismaClient } from "@prisma/client";
+import { FeaturePermission, Prisma, PrismaClient } from "@prisma/client";
 import dayjs from "dayjs";
 import { DateTime } from "luxon";
 
@@ -56,6 +56,7 @@ function makeUserWithMemberships(data: Prisma.UserCreateInput): Prisma.UserCreat
                 id: organizationId,
                 name: "Rubberdøk",
                 description: "Rubberdøk er en gjeng som lager gummibåter",
+                featurePermissions: [FeaturePermission.CABIN_BOOKING],
               },
             },
           },

--- a/src/server.ts
+++ b/src/server.ts
@@ -173,11 +173,14 @@ export async function initServer(dependencies: ServerDependencies, opts: Options
     let user: User | null = null;
     if (userId !== undefined && authenticated) {
       try {
+        req.log.debug({ userId }, "Fetching user");
         user = await apolloServerDependencies.userService.get(userId);
+        req.log.debug({ user }, "Found user");
       } catch (err) {
+        req.log.info({ userId }, "Error fetching user");
         if (err instanceof NotFoundError) {
           req.log.info({ userId }, "User not found, logging out");
-          authService.logout(req);
+          await authService.logout(req);
         } else {
           throw err;
         }

--- a/src/services/auth/plugin.ts
+++ b/src/services/auth/plugin.ts
@@ -4,7 +4,7 @@ import { BadRequestError, InternalServerError, PermissionDeniedError } from "@/d
 import { User } from "@/domain/users.js";
 
 export interface AuthService {
-  authorizationUrl(req: FastifyRequest, state?: string | null): string;
+  authorizationUrl(req: FastifyRequest, redirect?: string | null): string;
   authorizationCallback(req: FastifyRequest, data: { code: string }): Promise<User>;
   login(req: FastifyRequest, user: User): Promise<User>;
   logout(req: FastifyRequest): Promise<void>;

--- a/src/services/users/service.ts
+++ b/src/services/users/service.ts
@@ -205,6 +205,7 @@ export class UserService {
     const user = await this.usersRepository.get(id);
     return this.toDomainUser(user);
   }
+
   async getAll(): Promise<User[]> {
     const users = await this.usersRepository.getAll();
     return users.map((user) => this.toDomainUser(user));


### PR DESCRIPTION
### Changes
- Improve robustness of auth checking by checking that the user exists
- Add `hasFeaturePermission` to gql
- Tests
- Add some more seed data