### PR TITLE
chore: dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,9 @@ updates:
 
     labels:
       - dependencies
+
+    groups:
+      # @swc/core and @swc/core-linux-x64-musl versions should be kept in sync
+      swc:
+        patterns:
+          - "@swc/core*"


### PR DESCRIPTION
### Changes
- Add a group for `@swc/core` and `@swc/core-linux-x64-musl`, as they should be kept in sync.
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#example-3