### PR TITLE
chore(ci): add summary for integration test shards

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Build
         run: pnpm build:production
 
-  integration-test:
+  integration-test-matrix:
     name: Integration Test
     runs-on: ubuntu-latest
     strategy:
@@ -186,6 +186,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: coverage/integration
           flags: integrationtests,node
+
+  integration-test:
+    # Summary of all test shards
+    # Inspired by https://github.com/orgs/community/discussions/26822#discussioncomment-5122101
+    needs: [integration-test-matrix]
+    name: Integration Test
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check integration test results
+        # see https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#needs-context
+        # see https://stackoverflow.com/a/67532120/4907315
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}
+        run: exit 1
 
   build-image:
     name: Build Image

--- a/src/graphql/users/resolvers/Query/users.integration.test.ts
+++ b/src/graphql/users/resolvers/Query/users.integration.test.ts
@@ -24,7 +24,55 @@ describe("User queries", () => {
          * Create a super user
          * Create 3 additional users
          */
-        fail();
+        const superUser = await makeUser({ isSuperUser: true });
+        const user1 = await makeUser();
+        const user2 = await makeUser();
+        const user3 = await makeUser();
+
+        /**
+         * Act
+         *
+         * Perform a query to fetch all users
+         */
+        const { data, errors } = await client.query(
+          {
+            query: graphql(`
+              query users {
+                users {
+                  users {
+                    id
+                  }
+                  super {
+                    id
+                    email
+                  }
+                }
+              }
+            `),
+          },
+          {
+            userId: superUser.id,
+          }
+        );
+
+        /**
+         * Assert
+         *
+         * Assert that all users are returned, both in users and super without errors
+         */
+        expect(errors).toBeUndefined();
+        expect(data?.users.users.length).toBeGreaterThanOrEqual(4);
+        expect(data?.users.super.length).toBeGreaterThanOrEqual(4);
+
+        const usersIds = data?.users.users.map((user) => user.id);
+        expect(usersIds).toContain(user1.id);
+        expect(usersIds).toContain(user2.id);
+        expect(usersIds).toContain(user3.id);
+
+        const superIds = data?.users.super.map((user) => user.id);
+        expect(superIds).toContain(user1.id);
+        expect(superIds).toContain(user2.id);
+        expect(superIds).toContain(user3.id);
       });
     });
   });

--- a/src/graphql/users/resolvers/Query/users.integration.test.ts
+++ b/src/graphql/users/resolvers/Query/users.integration.test.ts
@@ -24,55 +24,7 @@ describe("User queries", () => {
          * Create a super user
          * Create 3 additional users
          */
-        const superUser = await makeUser({ isSuperUser: true });
-        const user1 = await makeUser();
-        const user2 = await makeUser();
-        const user3 = await makeUser();
-
-        /**
-         * Act
-         *
-         * Perform a query to fetch all users
-         */
-        const { data, errors } = await client.query(
-          {
-            query: graphql(`
-              query users {
-                users {
-                  users {
-                    id
-                  }
-                  super {
-                    id
-                    email
-                  }
-                }
-              }
-            `),
-          },
-          {
-            userId: superUser.id,
-          }
-        );
-
-        /**
-         * Assert
-         *
-         * Assert that all users are returned, both in users and super without errors
-         */
-        expect(errors).toBeUndefined();
-        expect(data?.users.users.length).toBeGreaterThanOrEqual(4);
-        expect(data?.users.super.length).toBeGreaterThanOrEqual(4);
-
-        const usersIds = data?.users.users.map((user) => user.id);
-        expect(usersIds).toContain(user1.id);
-        expect(usersIds).toContain(user2.id);
-        expect(usersIds).toContain(user3.id);
-
-        const superIds = data?.users.super.map((user) => user.id);
-        expect(superIds).toContain(user1.id);
-        expect(superIds).toContain(user2.id);
-        expect(superIds).toContain(user3.id);
+        fail();
       });
     });
   });


### PR DESCRIPTION
### Changes
- Add a job to summarize the results of the integration test shards so that we can easily require all shards to pass without having to manually select every shard in Github