### PR TITLE
chore: add dependabot group for prisma

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,7 @@ updates:
       swc:
         patterns:
           - "@swc/core*"
+      prisma:
+        patterns:
+          - "@prisma/client*"
+          - "prisma*"


### PR DESCRIPTION
### Changes
- `@prisma/client` and `prisma` versions should match, add a dependabot group for them