### PR TITLE
chore: remove migration health check

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -1,20 +1,20 @@
 {
-  "$schema": "https://json.schemastore.org/swcrc",
-  "module": {
-    "type": "es6",
-    "resolveFully": true
-  },
-  "jsc": {
-    "target": "es2022",
+	"$schema": "https://json.schemastore.org/swcrc",
+	"module": {
+		"type": "es6",
+		"resolveFully": true
+	},
+	"jsc": {
+		"target": "es2022",
 
-    "parser": {
-      "syntax": "typescript",
-      "decorators": true
-    },
+		"parser": {
+			"syntax": "typescript",
+			"decorators": true
+		},
 
-    "paths": {
-      "~/*": ["./src/*"]
-    },
-    "baseUrl": "."
-  }
+		"paths": {
+			"~/*": ["./src/*"]
+		},
+		"baseUrl": "."
+	}
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,8 @@
 {
-  "recommendations": ["GraphQL.vscode-graphql-syntax", "GraphQL.vscode-graphql", "biomejs.biome", "redhat.vscode-yaml"]
+	"recommendations": [
+		"GraphQL.vscode-graphql-syntax",
+		"GraphQL.vscode-graphql",
+		"biomejs.biome",
+		"redhat.vscode-yaml"
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-  "editor.defaultFormatter": "biomejs.biome",
-  "editor.codeActionsOnSave": {
-    "source.organizeImports.biome": true
-  }
+	"editor.defaultFormatter": "biomejs.biome",
+	"editor.codeActionsOnSave": {
+		"source.organizeImports.biome": true
+	}
 }

--- a/biome.json
+++ b/biome.json
@@ -1,27 +1,27 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
-  "vcs": {
-    "enabled": true,
-    "useIgnoreFile": true,
-    "clientKind": "git"
-  },
-  "organizeImports": {
-    "enabled": true
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true
-    }
-  },
-  "files": {
-    "ignore": [
-      "node_modules",
-      "dist",
-      "pnpm-lock.yaml",
-      "src/graphql/test-clients/integration/**/*.ts",
-      "src/graphql/test-clients/unit/**/*.ts",
-      "*.generated.ts"
-    ]
-  }
+	"$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
+	"vcs": {
+		"enabled": true,
+		"useIgnoreFile": true,
+		"clientKind": "git"
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"files": {
+		"ignore": [
+			"node_modules",
+			"dist",
+			"pnpm-lock.yaml",
+			"src/graphql/test-clients/integration/**/*.ts",
+			"src/graphql/test-clients/unit/**/*.ts",
+			"*.generated.ts"
+		]
+	}
 }

--- a/codegen.config.cjs
+++ b/codegen.config.cjs
@@ -21,100 +21,106 @@ To regenerate this file, run \`npm run generate:gql\`
 
 /** @type {import("@graphql-codegen/cli").CodegenConfig} */
 const config = {
-  overwrite: true,
-  schema: "src/graphql/**/schema.graphql",
-  emitLegacyCommonJSImports: false,
-  hooks: {
-    afterAllFileWrite: ["pnpm exec biome check --apply"],
-  },
-  ignoreNoDocuments: true,
-  generates: {
-    /**
-     * Generate typed document nodes for operations that are used for
-     * integration tests. Unfortunately, we can't use the same preset as
-     * for the unit tests because the integration tests require the queries to
-     * be passed as strings.
-     */
-    "src/graphql/test-clients/integration/": {
-      /* Only generate documents for integration tests */
-      documents: ["src/graphql/**/__tests__/integration/*.ts", "src/graphql/**/*.integration.test.ts"],
-      /* Client preset is a sensible default, see https://the-guild.dev/graphql/codegen/plugins/presets/preset-client */
-      preset: "client-preset",
-      config: {
-        /**
-         * By default, the return value of the `graphql(...)` function is a JavaScript object,
-         * but for integration tests, we need to pass a string instead.
-         * See https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#documentmode
-         */
-        documentMode: "string",
-        enumsAsTypes: true,
-      },
-      presetConfig: {
-        useTypeImports: true,
-        /* Fragment masking is only useful for actual clients, and it's not relevant for testing */
-        fragmentMasking: false,
-      },
-      plugins: [
-        {
-          add: {
-            content: generatedPrefix,
-          },
-        },
-      ],
-    },
-    /**
-     * Generate typed document nodes for operations that are used for unit tests.
-     */
-    "src/graphql/test-clients/unit/": {
-      /* Only generate documents for unit tests */
-      documents: ["src/graphql/**/__tests__/unit/*.ts", "src/graphql/**/*.unit.test.ts"],
-      /* Client preset is a sensible default, see https://the-guild.dev/graphql/codegen/plugins/presets/preset-client */
-      preset: "client-preset",
-      config: {
-        enumsAsTypes: true,
-      },
-      presetConfig: {
-        /* Fragment masking is only useful for actual clients, and it's not relevant for testing */
-        fragmentMasking: false,
-      },
-      plugins: [
-        {
-          add: {
-            content: generatedPrefix,
-          },
-        },
-      ],
-    },
-    "schema.graphql": {
-      plugins: [
-        {
-          add: {
-            content: generatedPrefixGraphQL,
-          },
-        },
-        "schema-ast",
-      ],
-    },
-    /**
-     * Generate resolvers and types for the GraphQL schema in
-     * a modular way.
-     * Docs: https://the-guild.dev/graphql/codegen/docs/guides/graphql-server-apollo-yoga-with-server-preset
-     */
-    "src/graphql": defineConfig(
-      {
-        mode: "modules",
-        emitLegacyCommonJSImports: false,
-        typeDefsFilePath: "./type-defs.generated.ts",
-        add: {
-          "./types.generated.ts": { content: generatedPrefix },
-        },
-        typesPluginsConfig: {
-          contextType: "~/lib/apollo-server.js#ApolloContext",
-        },
-      },
-      { schema: "src/graphql/**/*.{graphql}" },
-    ),
-  },
+	overwrite: true,
+	schema: "src/graphql/**/schema.graphql",
+	emitLegacyCommonJSImports: false,
+	hooks: {
+		afterAllFileWrite: ["pnpm exec biome check --apply"],
+	},
+	ignoreNoDocuments: true,
+	generates: {
+		/**
+		 * Generate typed document nodes for operations that are used for
+		 * integration tests. Unfortunately, we can't use the same preset as
+		 * for the unit tests because the integration tests require the queries to
+		 * be passed as strings.
+		 */
+		"src/graphql/test-clients/integration/": {
+			/* Only generate documents for integration tests */
+			documents: [
+				"src/graphql/**/__tests__/integration/*.ts",
+				"src/graphql/**/*.integration.test.ts",
+			],
+			/* Client preset is a sensible default, see https://the-guild.dev/graphql/codegen/plugins/presets/preset-client */
+			preset: "client-preset",
+			config: {
+				/**
+				 * By default, the return value of the `graphql(...)` function is a JavaScript object,
+				 * but for integration tests, we need to pass a string instead.
+				 * See https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#documentmode
+				 */
+				documentMode: "string",
+				enumsAsTypes: true,
+			},
+			presetConfig: {
+				useTypeImports: true,
+				/* Fragment masking is only useful for actual clients, and it's not relevant for testing */
+				fragmentMasking: false,
+			},
+			plugins: [
+				{
+					add: {
+						content: generatedPrefix,
+					},
+				},
+			],
+		},
+		/**
+		 * Generate typed document nodes for operations that are used for unit tests.
+		 */
+		"src/graphql/test-clients/unit/": {
+			/* Only generate documents for unit tests */
+			documents: [
+				"src/graphql/**/__tests__/unit/*.ts",
+				"src/graphql/**/*.unit.test.ts",
+			],
+			/* Client preset is a sensible default, see https://the-guild.dev/graphql/codegen/plugins/presets/preset-client */
+			preset: "client-preset",
+			config: {
+				enumsAsTypes: true,
+			},
+			presetConfig: {
+				/* Fragment masking is only useful for actual clients, and it's not relevant for testing */
+				fragmentMasking: false,
+			},
+			plugins: [
+				{
+					add: {
+						content: generatedPrefix,
+					},
+				},
+			],
+		},
+		"schema.graphql": {
+			plugins: [
+				{
+					add: {
+						content: generatedPrefixGraphQL,
+					},
+				},
+				"schema-ast",
+			],
+		},
+		/**
+		 * Generate resolvers and types for the GraphQL schema in
+		 * a modular way.
+		 * Docs: https://the-guild.dev/graphql/codegen/docs/guides/graphql-server-apollo-yoga-with-server-preset
+		 */
+		"src/graphql": defineConfig(
+			{
+				mode: "modules",
+				emitLegacyCommonJSImports: false,
+				typeDefsFilePath: "./type-defs.generated.ts",
+				add: {
+					"./types.generated.ts": { content: generatedPrefix },
+				},
+				typesPluginsConfig: {
+					contextType: "~/lib/apollo-server.js#ApolloContext",
+				},
+			},
+			{ schema: "src/graphql/**/*.{graphql}" },
+		),
+	},
 };
 
 module.exports = config;

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,49 +4,49 @@
  */
 
 module.exports = {
-  // Automatically clear mock calls, instances, contexts and results before every test
-  clearMocks: true,
+	// Automatically clear mock calls, instances, contexts and results before every test
+	clearMocks: true,
 
-  // Indicates whether the coverage information should be collected while executing the test
-  collectCoverage: false,
+	// Indicates whether the coverage information should be collected while executing the test
+	collectCoverage: false,
 
-  collectCoverageFrom: [
-    "src/**/*.{ts,js}",
-    "!**/test-clients/**",
-    "!**/__tests__/**",
-    "!**/__mocks__/**",
-    "!**/__types__.ts",
-    "!**/interfaces.ts",
-    "!**/seed.ts",
-    "!**/type-defs.ts",
-    "!src/graphql/types.generated.ts",
-    "!**/*.test.ts",
-  ],
+	collectCoverageFrom: [
+		"src/**/*.{ts,js}",
+		"!**/test-clients/**",
+		"!**/__tests__/**",
+		"!**/__mocks__/**",
+		"!**/__types__.ts",
+		"!**/interfaces.ts",
+		"!**/seed.ts",
+		"!**/type-defs.ts",
+		"!src/graphql/types.generated.ts",
+		"!**/*.test.ts",
+	],
 
-  // The directory where Jest should output its coverage files
-  coverageDirectory: "coverage/unit",
+	// The directory where Jest should output its coverage files
+	coverageDirectory: "coverage/unit",
 
-  coverageReporters: ["clover", "json", "lcov"],
+	coverageReporters: ["clover", "json", "lcov"],
 
-  // Indicates which provider should be used to instrument code for coverage
-  coverageProvider: "v8",
+	// Indicates which provider should be used to instrument code for coverage
+	coverageProvider: "v8",
 
-  // The glob patterns Jest uses to detect test files
-  testMatch: ["**/__tests__/unit/**/*.test.ts", "**/*.unit.test.ts"],
+	// The glob patterns Jest uses to detect test files
+	testMatch: ["**/__tests__/unit/**/*.test.ts", "**/*.unit.test.ts"],
 
-  modulePathIgnorePatterns: ["<rootDir>/dist/"],
+	modulePathIgnorePatterns: ["<rootDir>/dist/"],
 
-  extensionsToTreatAsEsm: [".ts"],
+	extensionsToTreatAsEsm: [".ts"],
 
-  // https://github.com/swc-project/jest/issues/64
-  // imports with .js extension fails
-  // this is a workaround
-  moduleNameMapper: {
-    "^(\\.{1,2}/.*)\\.js$": "$1",
-  },
+	// https://github.com/swc-project/jest/issues/64
+	// imports with .js extension fails
+	// this is a workaround
+	moduleNameMapper: {
+		"^(\\.{1,2}/.*)\\.js$": "$1",
+	},
 
-  // A map from regular expressions to paths to transformers
-  transform: {
-    "^.+\\.(t|j)sx?$": "@swc/jest",
-  },
+	// A map from regular expressions to paths to transformers
+	transform: {
+		"^.+\\.(t|j)sx?$": "@swc/jest",
+	},
 };

--- a/jest.integration.config.cjs
+++ b/jest.integration.config.cjs
@@ -5,7 +5,10 @@ const base = require("./jest.config.cjs");
  */
 
 module.exports = {
-  ...base,
-  testMatch: ["**/__tests__/integration/**/*.test.ts", "**/*.integration.test.ts"],
-  coverageDirectory: "coverage/integration",
+	...base,
+	testMatch: [
+		"**/__tests__/integration/**/*.test.ts",
+		"**/*.integration.test.ts",
+	],
+	coverageDirectory: "coverage/integration",
 };

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "connect-redis": "^7.1.0",
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
-    "execa": "^8.0.1",
     "fastify": "^4.25.1",
     "graphql": "^16.8.1",
     "graphql-scalars": "^1.22.4",
@@ -107,9 +106,18 @@
   },
   "pnpm": {
     "supportedArchitectures": {
-      "os": ["current", "linux"],
-      "cpu": ["current", "x64"],
-      "libc": ["current", "glibc"]
+      "os": [
+        "current",
+        "linux"
+      ],
+      "cpu": [
+        "current",
+        "x64"
+      ],
+      "libc": [
+        "current",
+        "glibc"
+      ]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ dependencies:
   dotenv:
     specifier: ^16.3.1
     version: 16.3.1
-  execa:
-    specifier: ^8.0.1
-    version: 8.0.1
   fastify:
     specifier: ^4.25.1
     version: 4.25.1
@@ -4021,6 +4018,7 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
 
   /data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -4378,21 +4376,6 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
     dev: true
-
-  /execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.1.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-    dev: false
 
   /executable@4.1.1:
     resolution: {integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==}
@@ -4815,11 +4798,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
-    dev: false
-
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
@@ -5091,11 +5069,6 @@ packages:
     engines: {node: '>=10.17.0'}
     dev: true
 
-  /human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
-    dev: false
-
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -5362,11 +5335,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: false
-
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -5423,6 +5391,7 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
 
   /isomorphic-ws@5.0.0(ws@8.14.2):
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
@@ -6215,6 +6184,7 @@ packages:
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    dev: true
 
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -6266,11 +6236,6 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
     dev: true
-
-  /mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-    dev: false
 
   /mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
@@ -6474,13 +6439,6 @@ packages:
       path-key: 3.1.1
     dev: true
 
-  /npm-run-path@5.1.0:
-    resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      path-key: 4.0.0
-    dev: false
-
   /nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
     dev: true
@@ -6549,13 +6507,6 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
     dev: true
-
-  /onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      mimic-fn: 4.0.0
-    dev: false
 
   /openid-client@5.6.1:
     resolution: {integrity: sha512-PtrWsY+dXg6y8mtMPyL/namZSYVz8pjXz3yJiBNZsEdCnu9miHLB4ELVC85WvneMKo2Rg62Ay7NkuCpM0bgiLQ==}
@@ -6718,11 +6669,7 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  /path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-    dev: false
+    dev: true
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -7355,6 +7302,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
+    dev: true
 
   /shebang-regex@1.0.0:
     resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
@@ -7364,6 +7312,7 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
 
   /shell-quote@1.8.1:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
@@ -7379,11 +7328,6 @@ packages:
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
-
-  /signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-    dev: false
 
   /signedsource@1.0.0:
     resolution: {integrity: sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==}
@@ -7610,11 +7554,6 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
     dev: true
-
-  /strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-    dev: false
 
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -8101,6 +8040,7 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
 
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}

--- a/scripts/create-super-user.cjs
+++ b/scripts/create-super-user.cjs
@@ -1,26 +1,26 @@
 #!/usr/bin/env node
 
 require("yargs")
-  .scriptName("create-super-user")
-  .usage("$0 <cmd> [args]")
-  .command(
-    "make-super [userId]",
-    "make an existing user a super user",
-    (yargs) => {
-      yargs.positional("userId", {
-        type: "string",
-        describe: "the user id to promote to a super user",
-      });
-    },
-    async (argv) => {
-      console.log("Promoting user to a super user...");
-      const { PrismaClient } = require("@prisma/client");
-      const prismaClient = new PrismaClient();
-      const updatedUser = await prismaClient.user.update({
-        where: { id: argv.userId },
-        data: { isSuperUser: true },
-      });
-      console.log(`Successfully promoted ${updatedUser.id} to a super user!`);
-    },
-  )
-  .help().argv;
+	.scriptName("create-super-user")
+	.usage("$0 <cmd> [args]")
+	.command(
+		"make-super [userId]",
+		"make an existing user a super user",
+		(yargs) => {
+			yargs.positional("userId", {
+				type: "string",
+				describe: "the user id to promote to a super user",
+			});
+		},
+		async (argv) => {
+			console.log("Promoting user to a super user...");
+			const { PrismaClient } = require("@prisma/client");
+			const prismaClient = new PrismaClient();
+			const updatedUser = await prismaClient.user.update({
+				where: { id: argv.userId },
+				data: { isSuperUser: true },
+			});
+			console.log(`Successfully promoted ${updatedUser.id} to a super user!`);
+		},
+	)
+	.help().argv;

--- a/src/lib/fastify/health-checks.ts
+++ b/src/lib/fastify/health-checks.ts
@@ -1,5 +1,4 @@
 import { FastifyPluginAsync } from "fastify";
-import { migrationHealthCheck } from "../prisma.js";
 
 const healthCheckPlugin: FastifyPluginAsync = async (app) => {
 	/**
@@ -11,28 +10,6 @@ const healthCheckPlugin: FastifyPluginAsync = async (app) => {
 		handler: async (req, reply) => {
 			reply.statusCode = 200;
 			return reply.send({ status: "ok" });
-		},
-	});
-
-	/**
-	 * Migration health check, used by the StartupProbe for the server container to check if the server is ready to
-	 * receive connections. See `infrastructure/modules/server/server_app.tf` for infrastructure details.
-	 * @returns `200: {"status": "ok"}` if the Prisma migrations in `prisma/migrations` are applied, `503: { "status": "error", "message": "Missing migrations" }` otherwise.
-	 */
-	app.route({
-		url: "/migration-health",
-		method: "GET",
-		handler: async (req, reply) => {
-			req.log.info("Health check");
-			const { status, message } = await migrationHealthCheck(app);
-			if (!status) {
-				req.log.info("Health check failed");
-				reply.statusCode = 503;
-				return reply.send({ message, status: "error" });
-			}
-			req.log.info("Health check succeeded");
-			reply.statusCode = 200;
-			return reply.send({ statusCode: 200, status: "ok" });
 		},
 	});
 };

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,6 +1,4 @@
 import { PrismaClient } from "@prisma/client";
-import { execa } from "execa";
-import { FastifyInstance } from "fastify";
 import { env } from "~/config.js";
 
 /**
@@ -12,44 +10,6 @@ export const prisma = globalForPrisma.prisma || new PrismaClient();
 if (env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
 
 export default prisma;
-
-interface MigrationHealthCheckReturnType {
-	status: boolean;
-	message?: string;
-}
-
-/**
- * Health check that returns `true` if the Prisma migrations are reflected
- * in the database, `false` otherwise.
- *
- * It calls the Prisma CLI directly with `prisma migrate status`,
- * which exits with code 0 if the migrations are reflected in the database,
- * and 1 otherwise.
- *
- * @returns status - `true` if the migrations are reflected in the database, `false` otherwise
- * @returns message - The error message if the migrations are not reflected in the database
- */
-export async function migrationHealthCheck(
-	app: FastifyInstance,
-): Promise<MigrationHealthCheckReturnType> {
-	try {
-		app.log.info("Running migration health check");
-		await execa("pnpm", ["exec", "prisma", "migrate", "status"], {
-			timeout: 15_000,
-		}).catch((err) => {
-			if (err.timedOut) app.log.error(err, "Migration health check timed out");
-			else app.log.error(err, "Migration health check failed");
-			throw err;
-		});
-		app.log.info("Migration health check passed");
-		return { status: true };
-	} catch (err) {
-		if (err instanceof Error) {
-			return { status: false, message: "Missing migrations" };
-		}
-		return { status: false, message: "Unknown error" };
-	}
-}
 
 export const prismaKnownErrorCodes = {
 	ERR_UNIQUE_CONSTRAINT_VIOLATION: "P2002",

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,16 +60,6 @@ interface Options {
  *
  * 6. Set up two health check routes:
  *    - `/-/health` - returns `200: {"status": "ok"}` if the server is running.
- *    - `/-/migration-health` - returns `200: {"status": "ok"}` if the Prisma migrations in `prisma/migrations`
- *      are reflected in the database, `503: { "status": "error", "message": "Missing migrations" }` otherwise.
- *      This health check is used by the StartupProbe for the server container to check if the server is ready to
- *      receive connections. See `infrastructure/modules/server/server_app.tf` for details.
- *
- *      The deployment flow is as follows:
- *      1. The server container is started, but the StartupProbe fails because the migrations are not reflected in the database.
- *      2. A separate, but identical, container is started, with `command: ["npm", "run", "db:migrate"]`
- *      3. The migration container runs the migrations, and then exits.
- *      4. The migrations are now reflected in the database, and the StartupProbe succeeds, allowing the server container to receive connections.
  *
  * 7. Start the Fastify server
  *


### PR DESCRIPTION
### Changes
- #329 added init containers, which removed the need for the custom migration logic. This PR removes the migration health check that is now unused.