### PR TITLE
:recycle: refactor: remove port usage in tests

### DIFF
--- a/src/__tests__/integration/server.test.ts
+++ b/src/__tests__/integration/server.test.ts
@@ -2,20 +2,39 @@ import { createServer, initServer } from "../../server.js";
 import { defaultTestDependenciesFactory } from "../dependencies-factory.js";
 
 describe("Server", () => {
-	let server: Awaited<ReturnType<typeof initServer>> | undefined;
+	describe("#createServer", () => {
+		let server: Awaited<ReturnType<typeof createServer>> | undefined;
 
-	beforeAll(async () => {
-		const dependencies = defaultTestDependenciesFactory();
-		server = await createServer(dependencies);
-	});
+		beforeAll(async () => {
+			const dependencies = defaultTestDependenciesFactory();
+			server = await createServer(dependencies);
+		});
 
-	test("Get data from server", async () => {
-		await server?.inject({ method: "GET", url: "/-/health" }).then((res) => {
-			expect(res.statusCode).toBe(200);
+		it("GET /-/health", async () => {
+			const res = await server?.inject({ method: "GET", url: "/-/health" });
+			expect(res?.statusCode).toBe(200);
+		});
+
+		afterAll(() => {
+			server?.close();
 		});
 	});
 
-	afterAll(() => {
-		server?.close();
+	describe("#initServer", () => {
+		let server: Awaited<ReturnType<typeof initServer>> | undefined;
+
+		beforeAll(async () => {
+			const dependencies = defaultTestDependenciesFactory();
+			server = await initServer(dependencies, { port: 4001, host: "0.0.0.0" });
+		});
+
+		it("GET /-/health should be available on port 4001", async () => {
+			const res = await fetch("http://localhost:4001/-/health");
+			expect(res.status).toBe(200);
+		});
+
+		afterAll(() => {
+			server?.close();
+		});
 	});
 });

--- a/src/__tests__/integration/server.test.ts
+++ b/src/__tests__/integration/server.test.ts
@@ -1,4 +1,4 @@
-import { initServer } from "../../server.js";
+import { createServer, initServer } from "../../server.js";
 import { defaultTestDependenciesFactory } from "../dependencies-factory.js";
 
 describe("Server", () => {
@@ -6,7 +6,7 @@ describe("Server", () => {
 
 	beforeAll(async () => {
 		const dependencies = defaultTestDependenciesFactory();
-		server = await initServer(dependencies, { port: 4003, host: "0.0.0.0" });
+		server = await createServer(dependencies);
 	});
 
 	test("Get data from server", async () => {

--- a/src/graphql/__tests__/integration/authentication.test.ts
+++ b/src/graphql/__tests__/integration/authentication.test.ts
@@ -19,10 +19,9 @@ describe("Apollo Context Authentication", () => {
 
 	beforeAll(async () => {
 		mockUserService = mockDeep<UserService>();
-		client = await newGraphQLTestClient(
-			{ port: 4389 },
-			{ apolloServerDependencies: { userService: mockUserService } },
-		);
+		client = await newGraphQLTestClient({
+			apolloServerDependencies: { userService: mockUserService },
+		});
 	});
 
 	it("should set ctx.user if a user with the userId in session exists", async () => {

--- a/src/graphql/__tests__/integration/errors.test.ts
+++ b/src/graphql/__tests__/integration/errors.test.ts
@@ -20,14 +20,11 @@ describe("GraphQL error handling", () => {
 
 	beforeAll(async () => {
 		mockOrganizationService = mockDeep<OrganizationService>();
-		client = await newGraphQLTestClient(
-			{ port: 4388 },
-			{
-				apolloServerDependencies: {
-					organizationService: mockOrganizationService,
-				},
+		client = await newGraphQLTestClient({
+			apolloServerDependencies: {
+				organizationService: mockOrganizationService,
 			},
-		);
+		});
 	});
 
 	it("should not report bad GraphQL request errors to Sentry", async () => {

--- a/src/graphql/organizations/resolvers/Mutation/createOrganization.integration.test.ts
+++ b/src/graphql/organizations/resolvers/Mutation/createOrganization.integration.test.ts
@@ -10,7 +10,7 @@ describe("Organization mutations", () => {
 	let client: GraphQLTestClient;
 
 	beforeAll(async () => {
-		client = await newGraphQLTestClient({ port: 4142 });
+		client = await newGraphQLTestClient();
 	});
 
 	afterAll(async () => {

--- a/src/graphql/test-clients/graphql-test-client.ts
+++ b/src/graphql/test-clients/graphql-test-client.ts
@@ -14,7 +14,7 @@ import {
 } from "~/__tests__/mocks/openIdClient.js";
 import { env } from "~/config.js";
 import { ApolloServerDependencies } from "~/lib/apollo-server.js";
-import { initServer } from "~/server.js";
+import { createServer } from "~/server.js";
 
 /**
  * A test client for integration testing GraphQL resolvers.
@@ -265,7 +265,7 @@ export class GraphQLTestClient {
  *
  *  beforeAll(async () => {
  *      // initialize the test client
- *     client = await newGraphQLTestClient({ port: <SOME PORT NUMBER> });
+ *     client = await newGraphQLTestClient();
  *  });
  *
  *  it("example test", () => {
@@ -291,7 +291,6 @@ export class GraphQLTestClient {
  * ```
  */
 export async function newGraphQLTestClient(
-	options: { port: number },
 	overrideDependencies: Partial<{
 		apolloServerDependencies: Partial<ApolloServerDependencies>;
 		openIdClient: MockOpenIdClient;
@@ -304,7 +303,6 @@ export async function newGraphQLTestClient(
 		...overrideDependencies,
 	});
 
-	const { port } = options;
-	const app = await initServer(dependencies, { port, host: "0.0.0.0" });
+	const app = await createServer(dependencies);
 	return new GraphQLTestClient({ app, dependencies, mockOpenIdClient });
 }

--- a/src/graphql/users/__tests__/integration/user.test.ts
+++ b/src/graphql/users/__tests__/integration/user.test.ts
@@ -9,7 +9,7 @@ describe("Users", () => {
 	let client: GraphQLTestClient;
 
 	beforeAll(async () => {
-		client = await newGraphQLTestClient({ port: 4143 });
+		client = await newGraphQLTestClient();
 	});
 
 	afterAll(async () => {

--- a/src/graphql/users/resolvers/Query/users.integration.test.ts
+++ b/src/graphql/users/resolvers/Query/users.integration.test.ts
@@ -10,7 +10,7 @@ describe("User queries", () => {
 	let client: GraphQLTestClient;
 
 	beforeAll(async () => {
-		client = await newGraphQLTestClient({ port: 4374 });
+		client = await newGraphQLTestClient();
 	});
 
 	afterAll(async () => {

--- a/src/services/auth/__tests__/integration/plugin.test.ts
+++ b/src/services/auth/__tests__/integration/plugin.test.ts
@@ -4,7 +4,7 @@ import { defaultTestDependenciesFactory } from "~/__tests__/dependencies-factory
 import { MockOpenIdClient } from "~/__tests__/mocks/openIdClient.js";
 import { env } from "~/config.js";
 import { errorCodes } from "~/domain/errors.js";
-import { initServer } from "~/server.js";
+import { createServer } from "~/server.js";
 
 describe("AuthPlugin", () => {
 	let app: FastifyInstance;
@@ -13,7 +13,7 @@ describe("AuthPlugin", () => {
 	beforeAll(async () => {
 		const dependencies = defaultTestDependenciesFactory();
 		({ mockOpenIdClient } = dependencies);
-		app = await initServer(dependencies, { port: 4001, host: "0.0.0.0" });
+		app = await createServer(dependencies);
 	});
 
 	describe("GET /auth/login?redirect=https://example.com/", () => {


### PR DESCRIPTION
### Changes
- Note to self: read documentation before you use stuff :) https://github.com/fastify/light-my-request
- Light my request, which we use for tests, does not rely on a server listening on a port.