### PR TITLE
chore: include source maps during build

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -123,6 +123,21 @@ jobs:
 
       - name: Build
         run: pnpm build:production
+      
+      - name: Sentry Release
+        # if: github.ref == 'refs/heads/main'
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_ORG: rbberdk
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_PROJECT: node
+        with:
+            version: ${{ github.sha }}
+            sourcemaps: './dist'
+            finalize: false
+            environment: production
+            ignore_empty: true
+            ignore_missing: true
 
   integration-test-matrix:
     name: Integration Test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -125,7 +125,7 @@ jobs:
         run: pnpm build:production
       
       - name: Sentry Release
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: getsentry/action-release@v1
         env:
           SENTRY_ORG: rbberdk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,8 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_PROJECT: node
         with:
+          version: ${{ github.sha }}
+          finalize: true
           environment: production
           ignore_empty: true
           ignore_missing: true

--- a/.swcrc
+++ b/.swcrc
@@ -4,6 +4,7 @@
 		"type": "es6",
 		"resolveFully": true
 	},
+	"sourceMaps": true,
 	"jsc": {
 		"target": "es2022",
 


### PR DESCRIPTION
First pass at including source maps for improved debugging in Sentry