### PR TITLE
:recycle: refactor: pass logging through context

### DIFF
--- a/src/graphql/events/resolvers/Mutation/signUp.ts
+++ b/src/graphql/events/resolvers/Mutation/signUp.ts
@@ -7,6 +7,6 @@ export const signUp: NonNullable<MutationResolvers["signUp"]> = async (
 ) => {
 	assertIsAuthenticated(ctx);
 	const { eventId } = data;
-	const signUp = await ctx.eventService.signUp(ctx.user.id, eventId);
+	const signUp = await ctx.eventService.signUp(ctx, ctx.user.id, eventId);
 	return { signUp };
 };

--- a/src/graphql/events/resolvers/Mutation/signUp.unit.test.ts
+++ b/src/graphql/events/resolvers/Mutation/signUp.unit.test.ts
@@ -90,6 +90,7 @@ describe("Event mutations", () => {
 				participationStatus: "CONFIRMED",
 			});
 			expect(eventService.signUp).toHaveBeenCalledWith(
+				expect.objectContaining({ user: contextValue.user }),
 				contextValue.req.session.userId,
 				expect.any(String),
 			);

--- a/src/graphql/test-clients/mock-apollo-server.ts
+++ b/src/graphql/test-clients/mock-apollo-server.ts
@@ -118,6 +118,7 @@ export const createMockApolloServer = (logger?: Partial<FastifyBaseLogger>) => {
 			listingService,
 			permissionService,
 			user,
+			log: mockDeep<FastifyBaseLogger>(logger),
 		};
 
 		return contextValue;

--- a/src/graphql/users/resolvers/Mutation/superUpdateUser.ts
+++ b/src/graphql/users/resolvers/Mutation/superUpdateUser.ts
@@ -5,7 +5,7 @@ export const superUpdateUser: NonNullable<
 > = async (_parent, { id, data }, ctx) => {
 	assertIsAuthenticated(ctx);
 
-	const user = await ctx.userService.superUpdateUser(ctx.user.id, id, {
+	const user = await ctx.userService.superUpdateUser(ctx, id, {
 		firstName: data.firstName,
 		lastName: data.lastName,
 		allergies: data.allergies ?? undefined,

--- a/src/graphql/users/resolvers/Mutation/superUpdateUser.unit.test.ts
+++ b/src/graphql/users/resolvers/Mutation/superUpdateUser.unit.test.ts
@@ -45,7 +45,9 @@ describe("User mutations", () => {
 
 			expect(errors).toBeUndefined();
 			expect(userService.superUpdateUser).toHaveBeenCalledWith(
-				callerUserId,
+				expect.objectContaining({
+					user: expect.objectContaining({ id: callerUserId }),
+				}),
 				updateUserId,
 				{
 					isSuperUser: true,

--- a/src/lib/apollo-server.ts
+++ b/src/lib/apollo-server.ts
@@ -13,7 +13,12 @@ import type {
 	Semester,
 } from "@prisma/client";
 import type { Transaction } from "@sentry/node";
-import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import type {
+	FastifyBaseLogger,
+	FastifyInstance,
+	FastifyReply,
+	FastifyRequest,
+} from "fastify";
 import { GraphQLError, type GraphQLFormattedError } from "graphql";
 import { merge } from "lodash-es";
 import type { BookingStatus } from "~/domain/cabins.js";
@@ -21,6 +26,7 @@ import { errorCodes, isUserFacingError } from "~/domain/errors.js";
 import type { Category, Event, SignUpAvailability } from "~/domain/events.js";
 import type { Role } from "~/domain/organizations.js";
 import type { User } from "~/domain/users.js";
+import type { Context } from "~/services/context.js";
 
 export function getFormatErrorHandler(log?: Partial<FastifyInstance["log"]>) {
 	const formatError = (
@@ -70,6 +76,7 @@ export interface ApolloContext extends ApolloServerDependencies {
 	res: FastifyReply;
 	req: FastifyRequest;
 	user: User | null;
+	log: FastifyBaseLogger;
 	transaction?: Transaction;
 }
 
@@ -125,7 +132,7 @@ interface IUserService {
 		},
 	): Promise<User>;
 	superUpdateUser(
-		callerId: string,
+		ctx: Context,
 		userToUpdateId: string,
 		data: {
 			firstName?: string | null;
@@ -217,7 +224,7 @@ interface IEventService {
 	): Promise<Event>;
 	get(id: string): Promise<Event>;
 	findMany(data?: { onlyFutureEvents?: boolean | null }): Promise<Event[]>;
-	signUp(userId: string, eventId: string): Promise<EventSignUp>;
+	signUp(ctx: Context, userId: string, eventId: string): Promise<EventSignUp>;
 	retractSignUp(userId: string, eventId: string): Promise<EventSignUp>;
 	canSignUpForEvent(userId: string, eventId: string): Promise<boolean>;
 	getSignUpAvailability(

--- a/src/lib/fastify/dependencies.ts
+++ b/src/lib/fastify/dependencies.ts
@@ -79,22 +79,13 @@ export function dependenciesFactory(): ServerDependencies {
 		mailService,
 		permissionService,
 	);
-	const userService = new UserService(
-		userRepository,
-		permissionService,
-		app.log.child({ service: "users" }),
-	);
+	const userService = new UserService(userRepository, permissionService);
 	const eventService = new EventService(
 		eventRepository,
 		permissionService,
 		userService,
-		app.log.child({ service: "events" }),
 	);
-	const authService = new AuthService(
-		userService,
-		feideClient,
-		app.log.child({ service: "auth" }),
-	);
+	const authService = new AuthService(userService, feideClient);
 
 	const apolloServerDependencies: ApolloServerDependencies = {
 		cabinService,

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -26,11 +26,21 @@ export const fastifyApolloSentryPlugin = (
 	app: FastifyInstance,
 ): ApolloServerPlugin<ApolloContext> => {
 	return {
-		async requestDidStart({ request, contextValue }) {
+		async requestDidStart({ contextValue, request }) {
+			contextValue.log.info(
+				{
+					graphql: {
+						query: request.query,
+						variables: request.variables,
+						method: request.http?.method,
+						operationName: request.operationName,
+					},
+				},
+				"incoming graphql request",
+			);
 			if (request.operationName) {
 				contextValue.transaction?.setName(request.operationName);
 			}
-
 			return {
 				// biome-ignore lint/nursery/useAwait: We need to use async/await API here.
 				async willSendResponse({ contextValue }) {
@@ -85,7 +95,7 @@ export const fastifyApolloSentryPlugin = (
 								});
 							}
 							if (originalError instanceof Error) {
-								ctx.contextValue.req.log.error(originalError);
+								ctx.contextValue.log.error(originalError);
 								app.Sentry.captureException(originalError);
 							}
 						});

--- a/src/services/auth/__tests__/integration/open-id-client.test.ts
+++ b/src/services/auth/__tests__/integration/open-id-client.test.ts
@@ -23,7 +23,6 @@ describe("AuthService", () => {
 		authService = new AuthService(
 			userService,
 			openIdClient,
-			undefined,
 			"https://example.com",
 		);
 	});

--- a/src/services/context.ts
+++ b/src/services/context.ts
@@ -1,0 +1,29 @@
+import type { FastifyBaseLogger } from "fastify";
+import type { User } from "~/domain/users.js";
+
+export type Context = {
+	user: User | null;
+	log: FastifyBaseLogger;
+};
+
+export function makeMockContext(
+	user?: User | null,
+	log?: FastifyBaseLogger,
+): Context {
+	return {
+		user: user ?? null,
+		log: log ?? {
+			child() {
+				return this;
+			},
+			debug() {},
+			error() {},
+			info() {},
+			fatal() {},
+			warn() {},
+			trace() {},
+			silent() {},
+			level: "debug",
+		},
+	};
+}

--- a/src/services/events/__tests__/integration/promote-from-waitlist.test.ts
+++ b/src/services/events/__tests__/integration/promote-from-waitlist.test.ts
@@ -3,6 +3,7 @@ import { ParticipationStatus } from "@prisma/client";
 import { merge } from "lodash-es";
 import { DateTime } from "luxon";
 import prisma from "~/lib/prisma.js";
+import { makeMockContext } from "~/services/context.js";
 import type { EventService } from "../../service.js";
 import {
 	makeDependencies,
@@ -78,7 +79,10 @@ describe("EventService", () => {
 			 *
 			 * Call promoteFromWaitList for the event
 			 */
-			const actual = await eventService.promoteFromWaitList(event.id);
+			const actual = await eventService.promoteFromWaitList(
+				makeMockContext(),
+				event.id,
+			);
 
 			/**
 			 * Assert

--- a/src/services/events/__tests__/integration/sign-up.test.ts
+++ b/src/services/events/__tests__/integration/sign-up.test.ts
@@ -2,11 +2,13 @@ import { faker } from "@faker-js/faker";
 import {
 	type Organization,
 	ParticipationStatus,
-	type User,
+	type User as PrismaUser,
 } from "@prisma/client";
 import { DateTime } from "luxon";
 import { InvalidArgumentError } from "~/domain/errors.js";
+import type { User } from "~/domain/users.js";
 import prisma from "~/lib/prisma.js";
+import { makeMockContext } from "~/services/context.js";
 import type { EventService } from "../../service.js";
 import { makeDependencies } from "./dependencies-factory.js";
 
@@ -56,7 +58,11 @@ describe("Event Sign Up", () => {
 			 *
 			 * 1. Sign up the user for the event.
 			 */
-			const actual = await eventService.signUp(user.id, event.id);
+			const actual = await eventService.signUp(
+				makeMockContext(),
+				user.id,
+				event.id,
+			);
 
 			/**
 			 * Assert.
@@ -109,7 +115,11 @@ describe("Event Sign Up", () => {
 			 *
 			 * 1. Sign up the user for the event.
 			 */
-			const actual = await eventService.signUp(user.id, event.id);
+			const actual = await eventService.signUp(
+				makeMockContext(),
+				user.id,
+				event.id,
+			);
 
 			/**
 			 * Assert.
@@ -162,7 +172,11 @@ describe("Event Sign Up", () => {
 			 *
 			 * 1. Sign up the user for the event.
 			 */
-			const actual = await eventService.signUp(user.id, event.id);
+			const actual = await eventService.signUp(
+				makeMockContext(),
+				user.id,
+				event.id,
+			);
 
 			/**
 			 * Assert.
@@ -238,7 +252,11 @@ describe("Event Sign Up", () => {
 					 *
 					 * 1. Sign up the user for the event.
 					 */
-					const actual = await eventService.signUp(user.id, event.id);
+					const actual = await eventService.signUp(
+						makeMockContext(),
+						user.id,
+						event.id,
+					);
 
 					/**
 					 * Assert.
@@ -306,7 +324,7 @@ describe("Event Sign Up", () => {
 			 * Sign up all users for the event.
 			 */
 			const promises = users.map((user) =>
-				eventService.signUp(user.id, event.id),
+				eventService.signUp(makeMockContext(), user.id, event.id),
 			);
 			const actual = await Promise.all(promises);
 
@@ -386,7 +404,7 @@ describe("Event Sign Up", () => {
 			 * Sign up all users for the event.
 			 */
 			const promises = users.map((user) =>
-				eventService.signUp(user.id, event.id),
+				eventService.signUp(makeMockContext(), user.id, event.id),
 			);
 			const actual = await Promise.all(promises);
 
@@ -456,7 +474,7 @@ describe("Event Sign Up", () => {
 			 *
 			 * Sign up for the event with sign ups disabled.
 			 */
-			const signUp = eventService.signUp(user.id, event.id);
+			const signUp = eventService.signUp(makeMockContext(), user.id, event.id);
 
 			/**
 			 * Assert
@@ -500,7 +518,7 @@ describe("Event Sign Up", () => {
 			 *
 			 * Sign up for the event with sign ups disabled.
 			 */
-			const signUp = eventService.signUp(user.id, event.id);
+			const signUp = eventService.signUp(makeMockContext(), user.id, event.id);
 
 			/**
 			 * Assert
@@ -524,7 +542,7 @@ function getCreateUserData() {
 
 async function makeUserWithOrganizationMembership(
 	userData: Partial<User> = {},
-): Promise<{ user: User; organization: Organization }> {
+): Promise<{ user: PrismaUser; organization: Organization }> {
 	const user = await prisma.user.create({
 		data: {
 			firstName: faker.person.firstName(),

--- a/src/services/events/__tests__/unit/events.test.ts
+++ b/src/services/events/__tests__/unit/events.test.ts
@@ -1,6 +1,5 @@
 import { faker } from "@faker-js/faker";
 import type { EventSlot } from "@prisma/client";
-import type { FastifyBaseLogger } from "fastify";
 import { mock, mockDeep } from "jest-mock-extended";
 import { DateTime } from "luxon";
 import {
@@ -11,6 +10,7 @@ import {
 import type { Event } from "~/domain/events.js";
 import { Role } from "~/domain/organizations.js";
 import type { User } from "~/domain/users.js";
+import { makeMockContext } from "~/services/context.js";
 import {
 	type EventRepository,
 	EventService,
@@ -906,7 +906,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.createCategory(
-				makeContext(mock<User>({ id: faker.string.uuid() })),
+				makeMockContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					name: faker.commerce.productName(),
 				},
@@ -935,7 +935,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.createCategory(
-				makeContext(mock<User>({ id: faker.string.uuid() })),
+				makeMockContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					name: faker.commerce.productName(),
 				},
@@ -964,7 +964,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.createCategory(
-				makeContext(mock<User>({ id: faker.string.uuid() })),
+				makeMockContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					name: faker.string.sample(101),
 				},
@@ -993,7 +993,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.createCategory(
-				makeContext(mock<User>({ id: faker.string.uuid() })),
+				makeMockContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					name: "",
 				},
@@ -1024,7 +1024,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.updateCategory(
-				makeContext(mock<User>({ id: faker.string.uuid() })),
+				makeMockContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 					name: faker.commerce.productName(),
@@ -1054,7 +1054,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.updateCategory(
-				makeContext(mock<User>({ id: faker.string.uuid() })),
+				makeMockContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 					name: faker.commerce.productName(),
@@ -1084,7 +1084,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.updateCategory(
-				makeContext(mock<User>({ id: faker.string.uuid() })),
+				makeMockContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 					name: faker.string.sample(101),
@@ -1114,7 +1114,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.updateCategory(
-				makeContext(mock<User>({ id: faker.string.uuid() })),
+				makeMockContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 					name: "",
@@ -1146,7 +1146,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.deleteCategory(
-				makeContext(mock<User>({ id: faker.string.uuid() })),
+				makeMockContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 				},
@@ -1175,7 +1175,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.deleteCategory(
-				makeContext(mock<User>({ id: faker.string.uuid() })),
+				makeMockContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 				},
@@ -1189,7 +1189,3 @@ describe("EventsService", () => {
 		});
 	});
 });
-
-function makeContext(user: User) {
-	return { user, log: mock<FastifyBaseLogger>() };
-}

--- a/src/services/events/__tests__/unit/events.test.ts
+++ b/src/services/events/__tests__/unit/events.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import type { EventSlot } from "@prisma/client";
+import type { FastifyBaseLogger } from "fastify";
 import { mock, mockDeep } from "jest-mock-extended";
 import { DateTime } from "luxon";
 import {
@@ -905,7 +906,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.createCategory(
-				{ user: mock<User>({ id: faker.string.uuid() }) },
+				makeContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					name: faker.commerce.productName(),
 				},
@@ -934,7 +935,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.createCategory(
-				{ user: mock<User>({ id: faker.string.uuid() }) },
+				makeContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					name: faker.commerce.productName(),
 				},
@@ -963,7 +964,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.createCategory(
-				{ user: mock<User>({ id: faker.string.uuid() }) },
+				makeContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					name: faker.string.sample(101),
 				},
@@ -992,7 +993,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.createCategory(
-				{ user: mock<User>({ id: faker.string.uuid() }) },
+				makeContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					name: "",
 				},
@@ -1023,7 +1024,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.updateCategory(
-				{ user: mock<User>({ id: faker.string.uuid() }) },
+				makeContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 					name: faker.commerce.productName(),
@@ -1053,7 +1054,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.updateCategory(
-				{ user: mock<User>({ id: faker.string.uuid() }) },
+				makeContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 					name: faker.commerce.productName(),
@@ -1083,7 +1084,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.updateCategory(
-				{ user: mock<User>({ id: faker.string.uuid() }) },
+				makeContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 					name: faker.string.sample(101),
@@ -1113,7 +1114,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.updateCategory(
-				{ user: mock<User>({ id: faker.string.uuid() }) },
+				makeContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 					name: "",
@@ -1145,7 +1146,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.deleteCategory(
-				{ user: mock<User>({ id: faker.string.uuid() }) },
+				makeContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 				},
@@ -1174,7 +1175,7 @@ describe("EventsService", () => {
 			 * Act
 			 */
 			const result = service.deleteCategory(
-				{ user: mock<User>({ id: faker.string.uuid() }) },
+				makeContext(mock<User>({ id: faker.string.uuid() })),
 				{
 					id: faker.string.uuid(),
 				},
@@ -1188,3 +1189,7 @@ describe("EventsService", () => {
 		});
 	});
 });
+
+function makeContext(user: User) {
+	return { user, log: mock<FastifyBaseLogger>() };
+}

--- a/src/services/users/__tests__/unit/update.test.ts
+++ b/src/services/users/__tests__/unit/update.test.ts
@@ -1,8 +1,9 @@
 import { faker } from "@faker-js/faker";
-import type { User } from "@prisma/client";
 import { type DeepMockProxy, mock, mockDeep } from "jest-mock-extended";
 import { DateTime } from "luxon";
 import { PermissionDeniedError } from "~/domain/errors.js";
+import type { User } from "~/domain/users.js";
+import { makeMockContext } from "~/services/context.js";
 import {
 	type PermissionService,
 	type UserRepository,
@@ -39,9 +40,13 @@ describe("UserService", () => {
 				 */
 				const callerUserId = faker.string.uuid();
 				const updateUserId = faker.string.uuid();
-				const actual = userService.superUpdateUser(callerUserId, updateUserId, {
-					isSuperUser: true,
-				});
+				const actual = userService.superUpdateUser(
+					makeMockContext(mock<User>({ id: callerUserId })),
+					updateUserId,
+					{
+						isSuperUser: true,
+					},
+				);
 
 				/**
 				 * Assert
@@ -74,9 +79,13 @@ describe("UserService", () => {
 				 */
 				const callerUserId = faker.string.uuid();
 				const updateUserId = faker.string.uuid();
-				const actual = userService.superUpdateUser(callerUserId, updateUserId, {
-					graduationYear: DateTime.now().year,
-				});
+				const actual = userService.superUpdateUser(
+					makeMockContext(mock<User>({ id: callerUserId })),
+					updateUserId,
+					{
+						graduationYear: DateTime.now().year,
+					},
+				);
 
 				/**
 				 * Assert
@@ -108,7 +117,7 @@ describe("UserService", () => {
 				 */
 				const callerUserId = faker.string.uuid();
 				const actual = userService.superUpdateUser(
-					callerUserId,
+					makeMockContext(mock<User>({ id: callerUserId })),
 					faker.string.uuid(),
 					{ isSuperUser: true },
 				);


### PR DESCRIPTION
### Changes
- Pass logging through context so that we gain the benefits of child loggers, etc.