### PR TITLE
:sparkles: feat(users): add flow for updating user study program

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,7 @@ CORS_CREDENTIALS=true
 CORS_ORIGINS=http://localhost:3000,https://sandbox.embed.apollographql.com,https://studio.apollographql.com/sandbox/explorer
 DATABASE_CONNECTION_STRING=postgresql://postgres:postgres@localhost:5433?schema=public
 FEIDE_BASE_URL=https://auth.dataporten.no
+FEIDE_GROUPS_API=https://groups-api.dataporten.no/groups/me/groups
 FEIDE_CLIENT_ID=fcaa9e30-a6d3-4809-8fea-cdd7b3de1c98
 FEIDE_REDIRECT_URI=http://localhost:4000/auth/authenticate
 LOG_ENABLED=true

--- a/.env.test
+++ b/.env.test
@@ -2,6 +2,7 @@ CORS_CREDENTIALS=true
 CORS_ORIGINS=http://localhost:3000
 DATABASE_CONNECTION_STRING="postgresql://postgres:postgres@localhost:5433?schema=test"
 FEIDE_BASE_URL=https://auth.dataporten.no
+FEIDE_GROUPS_API=https://groups-api.dataporten.no/groups/me/groups
 FEIDE_CLIENT_ID=fcaa9e30-a6d3-4809-8fea-cdd7b3de1c98
 FEIDE_CLIENT_SECRET=verysecret
 FEIDE_REDIRECT_URI=http://localhost:3000/authCallback

--- a/infrastructure/server/environments/production/terraform.tfvars
+++ b/infrastructure/server/environments/production/terraform.tfvars
@@ -68,6 +68,10 @@ environment_variables = [
   {
     name  = "REDIRECT_ORIGINS",
     value = "https://server-17vie6z9.blacksea-cdec4a8e.norwayeast.azurecontainerapps.io,https://indokntnu.no,https://indøkntnu.no"
+  },
+  {
+    name  = "FEIDE_GROUPS_API",
+    value = "https://groups-api.dataporten.no/groups/me/groups"
   }
 ]
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -480,6 +480,9 @@ type PrivateUser {
   """All organizations the user is a member of"""
   organizations: [Organization!]!
   phoneNumber: String
+
+  """The users' study program"""
+  studyProgram: StudyProgram
   username: String!
 }
 
@@ -645,6 +648,12 @@ enum Status {
   CONFIRMED
   PENDING
   REJECTED
+}
+
+type StudyProgram {
+  externalId: String!
+  id: ID!
+  name: String!
 }
 
 input SuperUpdateUserInput {

--- a/src/__tests__/mocks/openIdClient.ts
+++ b/src/__tests__/mocks/openIdClient.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from "http";
 import { faker } from "@faker-js/faker";
 import { type DeepMockProxy, mock, mockDeep } from "jest-mock-extended";
 import { merge } from "lodash-es";
@@ -52,5 +53,25 @@ function updateUserResponseMock(
 		name: user.name,
 		"https://n.feide.no/claims/userid_sec": [`feide:${user.email}`],
 		"https://n.feide.no/claims/eduPersonPrincipalName": user.email,
+	});
+	mockOpenIdClient.requestResource.mockResolvedValue({
+		body: Buffer.from(
+			JSON.stringify([
+				{
+					id: faker.string.uuid(),
+					displayName: faker.string.sample(20),
+					parent: "fc:org:ntnu.no",
+					type: "fc:fs:prg",
+					membership: {
+						basic: "member",
+						active: true,
+						displayName: "Student",
+						fsroles: ["STUDENT"],
+					},
+				},
+			]),
+			"utf8",
+		),
+		...mock<IncomingMessage>(),
 	});
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ const envVarsSchema = z.object({
 	CORS_CREDENTIALS: z.string().transform((v) => v === "true"),
 	CORS_ORIGINS: z.string().transform((v) => v.split(",")),
 	DATABASE_CONNECTION_STRING: z.string(),
+	FEIDE_GROUPS_API: z.string().url(),
 	FEIDE_BASE_URL: z.string().url(),
 	FEIDE_CLIENT_ID: z.string(),
 	FEIDE_CLIENT_SECRET: z.string(),

--- a/src/graphql/users/resolvers/PrivateUser.ts
+++ b/src/graphql/users/resolvers/PrivateUser.ts
@@ -4,4 +4,8 @@ export const PrivateUser: PrivateUserResolvers = {
 	organizations: (user, _args, ctx) => {
 		return ctx.organizationService.findMany({ userId: user.id });
 	},
+	studyProgram: (user, _args, ctx) => {
+		if (!user.studyProgramId) return null;
+		return ctx.userService.getStudyProgram({ id: user.studyProgramId });
+	},
 };

--- a/src/graphql/users/resolvers/StudyProgram.ts
+++ b/src/graphql/users/resolvers/StudyProgram.ts
@@ -1,0 +1,4 @@
+import type { StudyProgramResolvers } from "./../../types.generated.js";
+export const StudyProgram: StudyProgramResolvers = {
+	/* Implement StudyProgram resolver logic here */
+};

--- a/src/graphql/users/schema.graphql
+++ b/src/graphql/users/schema.graphql
@@ -113,4 +113,14 @@ type PrivateUser {
   true if the user is a super user, false otherwise
   """
   isSuperUser: Boolean!
+  """
+  The users' study program
+  """
+  studyProgram: StudyProgram
+}
+
+type StudyProgram {
+  id: ID!
+  name: String!
+  externalId: String!
 }

--- a/src/graphql/users/schema.mappers.ts
+++ b/src/graphql/users/schema.mappers.ts
@@ -1,6 +1,7 @@
-import type { User } from "~/domain/users.js";
+import type { StudyProgram, User } from "~/domain/users.js";
 
 export type PrivateUserMapper = User;
 export type PublicUserMapper = User;
 
 export type UsersResponseMapper = { users: User[] };
+export type StudyProgramMapper = StudyProgram;

--- a/src/lib/apollo-server.ts
+++ b/src/lib/apollo-server.ts
@@ -25,7 +25,7 @@ import type { BookingStatus } from "~/domain/cabins.js";
 import { errorCodes, isUserFacingError } from "~/domain/errors.js";
 import type { Category, Event, SignUpAvailability } from "~/domain/events.js";
 import type { Role } from "~/domain/organizations.js";
-import type { User } from "~/domain/users.js";
+import type { StudyProgram, User } from "~/domain/users.js";
 import type { Context } from "~/services/context.js";
 
 export function getFormatErrorHandler(log?: Partial<FastifyInstance["log"]>) {
@@ -146,6 +146,13 @@ interface IUserService {
 	login(id: string): Promise<User>;
 	create(data: Prisma.UserCreateInput): Promise<User>;
 	canUpdateYear(user: Pick<User, "graduationYearUpdatedAt">): boolean;
+	getStudyProgram(
+		by: { id: string } | { externalId: string },
+	): Promise<StudyProgram | null>;
+	createStudyProgram(studyProgram: {
+		name: string;
+		externalId: string;
+	}): Promise<StudyProgram>;
 }
 
 export interface BookingData {

--- a/src/lib/fastify/dependencies.ts
+++ b/src/lib/fastify/dependencies.ts
@@ -24,11 +24,16 @@ import { createRedisClient } from "../redis.js";
 import { envToLogger } from "./logging.js";
 
 interface IAuthService {
-	authorizationCallback(
+	userLoginCallback(req: FastifyRequest, data: { code: string }): Promise<User>;
+	studyProgramCallback(
 		req: FastifyRequest,
 		data: { code: string },
 	): Promise<User>;
-	authorizationUrl(req: FastifyRequest, state?: string | null): string;
+	authorizationUrl(
+		req: FastifyRequest,
+		postAuthorizationRedirectUrl?: string | null,
+		kind?: "login" | "studyProgram",
+	): string;
 	logout(req: FastifyRequest): Promise<void>;
 	login(req: FastifyRequest, user: User): Promise<User>;
 }

--- a/src/repositories/users/index.ts
+++ b/src/repositories/users/index.ts
@@ -1,13 +1,13 @@
 import type { Prisma, PrismaClient, User } from "@prisma/client";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library.js";
 import { InvalidArgumentError, NotFoundError } from "~/domain/errors.js";
-import type { StudyProgram } from "~/domain/users.js";
+import type { StudyProgram, User as DomainUser } from "~/domain/users.js";
 import { prismaKnownErrorCodes } from "~/lib/prisma.js";
 
 export class UserRepository {
 	constructor(private db: PrismaClient) {}
 
-	update(id: string, data: Prisma.UserUpdateInput): Promise<User> {
+	update(id: string, data: Partial<DomainUser>): Promise<User> {
 		return this.db.user.update({
 			where: {
 				id,

--- a/src/services/auth/clients.ts
+++ b/src/services/auth/clients.ts
@@ -6,7 +6,10 @@ const feideIssuer = await Issuer.discover(env.FEIDE_BASE_URL);
 const feideClient = new feideIssuer.Client({
 	client_id: env.FEIDE_CLIENT_ID,
 	client_secret: env.FEIDE_CLIENT_SECRET,
-	redirect_uris: [new URL("/auth/authenticate", env.SERVER_URL).toString()],
+	redirect_uris: [
+		new URL("/auth/authenticate", env.SERVER_URL).toString(),
+		new URL("/auth/study-program", env.SERVER_URL).toString(),
+	],
 	response_types: ["code"],
 });
 

--- a/src/services/users/service.ts
+++ b/src/services/users/service.ts
@@ -18,7 +18,7 @@ export interface UserRepository {
 	get(id: string): Promise<PrismaUser>;
 	getAll(): Promise<PrismaUser[]>;
 	getByFeideId(feideId: string): Promise<PrismaUser>;
-	update(id: string, data: Prisma.UserUpdateInput): Promise<PrismaUser>;
+	update(id: string, user: Partial<User>): Promise<PrismaUser>;
 	create(data: Prisma.UserCreateInput): Promise<PrismaUser>;
 	createStudyProgram(studyProgram: {
 		name: string;
@@ -57,6 +57,7 @@ export class UserService {
 			allergies: string | null;
 			phoneNumber: string | null;
 			isSuperUser?: boolean | null;
+			studyProgramId?: string | null;
 		}>,
 	): Promise<User> {
 		const { isSuperUser } = await this.permissionService.isSuperUser(
@@ -102,6 +103,11 @@ export class UserService {
 				.boolean()
 				.nullish()
 				.transform((val) => val ?? undefined),
+			studyProgramId: z
+				.string()
+				.uuid()
+				.nullish()
+				.transform((val) => val ?? undefined),
 		});
 		const validatedData = schema.parse(data);
 
@@ -126,6 +132,7 @@ export class UserService {
 			graduationYear: number | null;
 			allergies: string | null;
 			phoneNumber: string | null;
+			studyProgramId: string | null;
 		}>,
 	): Promise<User> {
 		const schema = z.object({
@@ -153,6 +160,10 @@ export class UserService {
 				.string()
 				.nullish()
 				.transform((val) => val ?? undefined),
+			studyProgramId: z
+				.string()
+				.nullish()
+				.transform((val) => val ?? undefined),
 			phoneNumber: z
 				.string()
 				.regex(/^(0047|\+47|47)?[49]\d{7}$/)
@@ -175,6 +186,7 @@ export class UserService {
 				phoneNumber,
 				allergies,
 				graduationYear,
+				studyProgramId,
 			} = schema.parse(data);
 			let firstLogin: boolean | undefined;
 			let newGraduationYear: number | undefined = graduationYear;
@@ -194,6 +206,7 @@ export class UserService {
 				graduationYear: newGraduationYear,
 				graduationYearUpdatedAt,
 				firstLogin,
+				studyProgramId,
 			});
 
 			return this.toDomainUser(updatedUser);


### PR DESCRIPTION
This is still a little rough around the edges, but it works. Fetch study programs using the Feide groups API for users using the OAuth flow. This means that users can update study programs themselves.

Currently assume that users just have a single study program.

### Changes
- Add flow for fetching a users' study programs using the feide groups api
- Small changes to user repository and service to accommodate updating users with study program
- Add study program to the GraphQL api
- Add integration tests for study programs