### PR TITLE
:sparkles: feat(events): bump users from wait list and notify 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,7 @@
 {
 	"editor.formatOnSave": true,
 	"[typescript][javascript][json][typescriptreact]": {
-		"editor.defaultFormatter": "biomejs.biome",
-		"editor.codeActionsOnSave": {
-			"source.organizeImports.biome": "explicit"
-		}
+		"editor.defaultFormatter": "biomejs.biome"
 	},
 	"[prisma]": {
 		"editor.defaultFormatter": "Prisma.prisma"

--- a/src/__tests__/dependencies-factory.ts
+++ b/src/__tests__/dependencies-factory.ts
@@ -15,6 +15,7 @@ import { UserRepository } from "~/repositories/users/index.js";
 import { AuthService } from "~/services/auth/service.js";
 import { CabinService } from "~/services/cabins/service.js";
 import { EventService } from "~/services/events/service.js";
+import type { SignUpQueueType } from "~/services/events/worker.js";
 import { ListingService } from "~/services/listings/service.js";
 import { MailService } from "~/services/mail/index.js";
 import type { EmailQueueType } from "~/services/mail/worker.js";
@@ -68,6 +69,7 @@ export function makeTestServices(
 		eventRepository,
 		permissionService,
 		userService,
+		mockDeep<SignUpQueueType>(),
 	);
 	const authService = new AuthService(userService, openIdClient);
 	const products = new ProductService(

--- a/src/lib/fastify/message-queue.ts
+++ b/src/lib/fastify/message-queue.ts
@@ -2,8 +2,13 @@ import type { FastifyPluginAsync } from "fastify";
 import fp from "fastify-plugin";
 import type { Redis } from "ioredis";
 import { InternalServerError } from "~/domain/errors.js";
+import {
+	SignUpQueueName,
+	type SignUpQueueType,
+} from "~/services/events/worker.js";
 import type { EmailQueueType } from "~/services/mail/worker.js";
 import type { PaymentProcessingQueueType } from "~/services/products/worker.js";
+import { PaymentProcessingQueueName } from "~/services/products/worker.js";
 import { Queue } from "../bullmq/queue.js";
 
 type FastifyMessageQueuePluginOptions = {
@@ -13,7 +18,8 @@ type FastifyMessageQueuePluginOptions = {
 
 type KnownQueues = {
 	email: EmailQueueType;
-	"payment-processing": PaymentProcessingQueueType;
+	[PaymentProcessingQueueName]: PaymentProcessingQueueType;
+	[SignUpQueueName]: SignUpQueueType;
 };
 
 declare module "fastify" {

--- a/src/lib/postmark.ts
+++ b/src/lib/postmark.ts
@@ -21,6 +21,9 @@ type CabinBookingReceipt = {
 type Model = {
 	[TemplateAlias.EVENT_WAIT_LIST]: {
 		subject: string;
+		eventName: string;
+		eventStartAt: string;
+		location: string;
 	};
 	[TemplateAlias.CABIN_BOOKING_RECEIPT]: CabinBookingReceipt;
 	[TemplateAlias.WELCOME]: {

--- a/src/services/events/__tests__/integration/dependencies-factory.ts
+++ b/src/services/events/__tests__/integration/dependencies-factory.ts
@@ -10,6 +10,7 @@ import type { EmailQueueType } from "~/services/mail/worker.js";
 import { PermissionService } from "~/services/permissions/service.js";
 import { UserService } from "~/services/users/service.js";
 import { EventService } from "../../service.js";
+import type { SignUpQueueType } from "../../worker.js";
 
 export function makeDependencies() {
 	const eventRepository = new EventRepository(prisma);
@@ -30,6 +31,7 @@ export function makeDependencies() {
 		eventRepository,
 		permissionService,
 		userService,
+		mockDeep<SignUpQueueType>(),
 	);
 	return { eventService };
 }

--- a/src/services/events/__tests__/integration/sign-off-waitlist-promotion.test.ts
+++ b/src/services/events/__tests__/integration/sign-off-waitlist-promotion.test.ts
@@ -427,6 +427,6 @@ describe("EventService", () => {
 				);
 				expect(signUpAvailability).toBe("ON_WAITLIST");
 			}
-		});
+		}, 10_000);
 	});
 });

--- a/src/services/events/__tests__/integration/sign-off-waitlist-promotion.test.ts
+++ b/src/services/events/__tests__/integration/sign-off-waitlist-promotion.test.ts
@@ -1,0 +1,432 @@
+import { faker } from "@faker-js/faker";
+import { QueueEvents } from "bullmq";
+import { Redis } from "ioredis";
+import { type DeepMockProxy, mockDeep } from "jest-mock-extended";
+import { range } from "lodash-es";
+import { DateTime } from "luxon";
+import type { Logger } from "pino";
+import type { ServerClient } from "postmark";
+import { env } from "~/config.js";
+import { Queue } from "~/lib/bullmq/queue.js";
+import { Worker } from "~/lib/bullmq/worker.js";
+import prisma from "~/lib/prisma.js";
+import type { IOrganizationService } from "~/lib/server.js";
+import { EventRepository } from "~/repositories/events/repository.js";
+import { MemberRepository } from "~/repositories/organizations/members.js";
+import { OrganizationRepository } from "~/repositories/organizations/organizations.js";
+import { UserRepository } from "~/repositories/users/index.js";
+import { makeMockContext } from "~/services/context.js";
+import { MailService } from "~/services/mail/index.js";
+import {
+	type EmailQueueType,
+	type EmailWorkerType,
+	getEmailHandler,
+} from "~/services/mail/worker.js";
+import { OrganizationService } from "~/services/organizations/service.js";
+import { PermissionService } from "~/services/permissions/service.js";
+import { UserService } from "~/services/users/service.js";
+import { EventService } from "../../service.js";
+import {
+	SignUpQueueName,
+	type SignUpQueueType,
+	type SignUpWorkerType,
+	getSignUpWorkerHandler,
+} from "../../worker.js";
+
+describe("EventService", () => {
+	let redis: Redis;
+	let emailQueue: EmailQueueType;
+	let signUpQueue: SignUpQueueType;
+	let eventService: EventService;
+	let userService: UserService;
+	let signUpWorker: SignUpWorkerType;
+	let emailWorker: EmailWorkerType;
+	let organizationService: IOrganizationService;
+	let queueEventsRedis: Redis;
+	let signUpQueueEvents: QueueEvents;
+	let emailQueueEvents: QueueEvents;
+	let mailClient: DeepMockProxy<ServerClient>;
+
+	beforeAll(() => {
+		redis = new Redis(env.REDIS_CONNECTION_STRING, {
+			maxRetriesPerRequest: 0,
+		});
+		queueEventsRedis = new Redis(env.REDIS_CONNECTION_STRING, {
+			maxRetriesPerRequest: 0,
+		});
+
+		emailQueue = new Queue("email", { connection: redis });
+		signUpQueue = new Queue(SignUpQueueName, { connection: redis });
+		mailClient = mockDeep<ServerClient>();
+
+		const userRepository = new UserRepository(prisma);
+		const organizationRepository = new OrganizationRepository(prisma);
+		const memberRepository = new MemberRepository(prisma);
+		const permissionService = new PermissionService(
+			memberRepository,
+			userRepository,
+			organizationRepository,
+		);
+		const eventRepository = new EventRepository(prisma);
+		userService = new UserService(
+			userRepository,
+			permissionService,
+			emailQueue,
+		);
+		eventService = new EventService(
+			eventRepository,
+			permissionService,
+			userService,
+			signUpQueue,
+		);
+		organizationService = new OrganizationService(
+			organizationRepository,
+			memberRepository,
+			permissionService,
+		);
+		const mailService = new MailService(mailClient, env.NO_REPLY_EMAIL);
+
+		const emailWorkerHandler = getEmailHandler({
+			eventService,
+			userService,
+			mailService,
+		});
+		emailWorker = new Worker(
+			emailWorkerHandler.name,
+			emailWorkerHandler.handler,
+			{
+				connection: redis,
+			},
+		);
+
+		const signUpWorkerHandler = getSignUpWorkerHandler({
+			events: eventService,
+			emailQueue,
+			log: mockDeep<Logger>(),
+		});
+
+		signUpWorker = new Worker(
+			signUpWorkerHandler.name,
+			signUpWorkerHandler.handler,
+			{
+				connection: redis,
+			},
+		);
+
+		signUpQueueEvents = new QueueEvents(signUpWorkerHandler.name, {
+			connection: queueEventsRedis,
+		});
+		emailQueueEvents = new QueueEvents(emailWorkerHandler.name, {
+			connection: queueEventsRedis,
+		});
+	});
+
+	afterAll(async () => {
+		await emailQueue.close();
+		await signUpQueue.close();
+		await signUpWorker.close();
+		await emailWorker.close();
+		await signUpQueueEvents.close();
+		redis.disconnect();
+		queueEventsRedis.disconnect();
+	});
+
+	describe("#retractSignUp", () => {
+		it("should promote the first user on the wait list, and send them an email", async () => {
+			/**
+			 * Create two users, one event, and sign up both users for the event.
+			 * The first should be CONFIRMED, the second should be WAIT_LIST.
+			 */
+			const eventOwner = await userService.create({
+				firstName: faker.person.firstName(),
+				lastName: faker.person.lastName(),
+				username: faker.string.uuid(),
+				email: faker.internet.email({ firstName: faker.string.uuid() }),
+				feideId: faker.string.uuid(),
+			});
+			const confirmedUser = await userService.create({
+				firstName: faker.person.firstName(),
+				lastName: faker.person.lastName(),
+				username: faker.string.uuid(),
+				email: faker.internet.email({ firstName: faker.string.uuid() }),
+				feideId: faker.string.uuid(),
+				graduationYear: DateTime.now().year + 2,
+			});
+			const waitListUser = await userService.create({
+				firstName: faker.person.firstName(),
+				lastName: faker.person.lastName(),
+				username: faker.string.uuid(),
+				email: faker.internet.email({ firstName: faker.string.uuid() }),
+				feideId: faker.string.uuid(),
+				graduationYear: DateTime.now().year + 2,
+			});
+
+			const organization = await organizationService.create(eventOwner.id, {
+				name: faker.string.sample(20),
+			});
+
+			let event = await eventService.create(
+				eventOwner.id,
+				organization.id,
+				{
+					name: faker.string.sample(20),
+					startAt: DateTime.now().plus({ days: 1 }).toJSDate(),
+					endAt: DateTime.now().plus({ days: 1, hours: 2 }).toJSDate(),
+				},
+				{
+					capacity: 1,
+					signUpsStartAt: faker.date.past(),
+					signUpsEndAt: faker.date.future(),
+					slots: [{ capacity: 1, gradeYears: [1, 2, 3, 4, 5] }],
+					signUpsEnabled: true,
+				},
+			);
+
+			const ctx = makeMockContext(confirmedUser);
+			const confirmedSignUp = await eventService.signUp(
+				ctx,
+				confirmedUser.id,
+				event.id,
+			);
+			const waitListSignUp = await eventService.signUp(
+				ctx,
+				waitListUser.id,
+				event.id,
+			);
+
+			expect(confirmedSignUp.participationStatus).toBe("CONFIRMED");
+			expect(waitListSignUp.participationStatus).toBe("ON_WAITLIST");
+			event = await eventService.get(event.id);
+			expect(event.signUpDetails?.remainingCapacity).toBe(0);
+
+			/**
+			 * Act
+			 *
+			 * Retract the confirmed user's sign up, and wait for jobs to finish
+			 */
+			await eventService.retractSignUp(confirmedUser.id, event.id);
+			const signUpJobs = await signUpQueue.getJobs();
+			await Promise.all(
+				signUpJobs.map((job) =>
+					job
+						.waitUntilFinished(signUpQueueEvents)
+						.then((res) => expect(res.ok).toBe(true)),
+				),
+			);
+			const emailJobs = await emailQueue.getJobs();
+			await Promise.all(
+				emailJobs.map((job) => job.waitUntilFinished(emailQueueEvents)),
+			);
+
+			event = await eventService.get(event.id);
+			expect(event.signUpDetails?.remainingCapacity).toBe(0);
+
+			/**
+			 * Assert
+			 *
+			 * The confirmed user's sign up should be cancelled, and the wait list user should be promoted
+			 * to confirmed.
+			 * The promoted user should receive an email.
+			 */
+			const retractedSignUp = await eventService.getSignUpAvailability(
+				confirmedUser.id,
+				event.id,
+			);
+			expect(retractedSignUp).toBe("WAITLIST_AVAILABLE");
+			const promotedSignUp = await eventService.getSignUpAvailability(
+				waitListUser.id,
+				event.id,
+			);
+			expect(promotedSignUp).toBe("CONFIRMED");
+			expect(mailClient.sendEmailWithTemplate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					To: waitListUser.email,
+					From: env.NO_REPLY_EMAIL,
+					TemplateAlias: "event-wait-list",
+					TemplateModel: expect.objectContaining({
+						eventName: event.name,
+						eventStartAt: expect.any(String),
+					}),
+				}),
+			);
+		});
+
+		it("stress test", async () => {
+			/**
+			 * Create two users, one event, and sign up both users for the event.
+			 * The first should be CONFIRMED, the second should be WAIT_LIST.
+			 */
+			const eventOwner = await userService.create({
+				firstName: faker.person.firstName(),
+				lastName: faker.person.lastName(),
+				username: faker.string.uuid(),
+				email: faker.internet.email({ firstName: faker.string.uuid() }),
+				feideId: faker.string.uuid(),
+			});
+			const confirmedUsers = await Promise.all(
+				range(0, 100).map(
+					async () =>
+						await userService.create({
+							firstName: faker.person.firstName(),
+							lastName: faker.person.lastName(),
+							username: faker.string.uuid(),
+							email: faker.internet.email({ firstName: faker.string.uuid() }),
+							feideId: faker.string.uuid(),
+							graduationYear: DateTime.now().year + 2,
+						}),
+				),
+			);
+			const waitListUsers = await Promise.all(
+				range(0, 100).map(
+					async () =>
+						await userService.create({
+							firstName: faker.person.firstName(),
+							lastName: faker.person.lastName(),
+							username: faker.string.uuid(),
+							email: faker.internet.email({ firstName: faker.string.uuid() }),
+							feideId: faker.string.uuid(),
+							graduationYear: DateTime.now().year + 2,
+						}),
+				),
+			);
+
+			const shouldRemainOnWaitListUsers = await Promise.all(
+				range(0, 100).map(
+					async () =>
+						await userService.create({
+							firstName: faker.person.firstName(),
+							lastName: faker.person.lastName(),
+							username: faker.string.uuid(),
+							email: faker.internet.email({ firstName: faker.string.uuid() }),
+							feideId: faker.string.uuid(),
+							graduationYear: DateTime.now().year + 2,
+						}),
+				),
+			);
+
+			const organization = await organizationService.create(eventOwner.id, {
+				name: faker.string.sample(20),
+			});
+
+			let event = await eventService.create(
+				eventOwner.id,
+				organization.id,
+				{
+					name: faker.string.sample(20),
+					startAt: DateTime.now().plus({ days: 1 }).toJSDate(),
+					endAt: DateTime.now().plus({ days: 1, hours: 2 }).toJSDate(),
+				},
+				{
+					capacity: 100,
+					signUpsStartAt: faker.date.past(),
+					signUpsEndAt: faker.date.future(),
+					slots: [
+						{ capacity: 50, gradeYears: [1, 2, 3, 4, 5] },
+						{ capacity: 50, gradeYears: [1, 2, 3, 4, 5] },
+					],
+					signUpsEnabled: true,
+				},
+			);
+
+			for (const user of confirmedUsers) {
+				const ctx = makeMockContext(user);
+				const confirmedSignUp = await eventService.signUp(
+					ctx,
+					user.id,
+					event.id,
+				);
+				expect(confirmedSignUp.participationStatus).toBe("CONFIRMED");
+			}
+
+			for (const user of waitListUsers) {
+				const ctx = makeMockContext(user);
+				const waitListSignUp = await eventService.signUp(
+					ctx,
+					user.id,
+					event.id,
+				);
+				expect(waitListSignUp.participationStatus).toBe("ON_WAITLIST");
+			}
+
+			for (const user of shouldRemainOnWaitListUsers) {
+				const ctx = makeMockContext(user);
+				const waitListSignUp = await eventService.signUp(
+					ctx,
+					user.id,
+					event.id,
+				);
+				expect(waitListSignUp.participationStatus).toBe("ON_WAITLIST");
+			}
+
+			event = await eventService.get(event.id);
+			expect(event.signUpDetails?.remainingCapacity).toBe(0);
+
+			/**
+			 * Act
+			 *
+			 * Retract the confirmed user's sign up, and wait for jobs to finish
+			 */
+			await Promise.all(
+				confirmedUsers.map((user) =>
+					eventService.retractSignUp(user.id, event.id),
+				),
+			);
+			const signUpJobs = await signUpQueue.getJobs();
+			await Promise.all(
+				signUpJobs.map((job) =>
+					job
+						.waitUntilFinished(signUpQueueEvents)
+						.then((res) => expect(res.ok).toBe(true)),
+				),
+			);
+			const emailJobs = await emailQueue.getJobs();
+			await Promise.all(
+				emailJobs.map((job) => job.waitUntilFinished(emailQueueEvents)),
+			);
+
+			event = await eventService.get(event.id);
+			expect(event.signUpDetails?.remainingCapacity).toBe(0);
+
+			/**
+			 * Assert
+			 *
+			 * The confirmed user's sign up should be cancelled, and the wait list user should be promoted
+			 * to confirmed.
+			 * The promoted user should receive an email.
+			 */
+			for (const user of confirmedUsers) {
+				const retractedSignUp = await eventService.getSignUpAvailability(
+					user.id,
+					event.id,
+				);
+				expect(retractedSignUp).toBe("WAITLIST_AVAILABLE");
+			}
+			for (const user of waitListUsers) {
+				const promotedSignUp = await eventService.getSignUpAvailability(
+					user.id,
+					event.id,
+				);
+				expect(promotedSignUp).toBe("CONFIRMED");
+				expect(mailClient.sendEmailWithTemplate).toHaveBeenCalledWith(
+					expect.objectContaining({
+						To: user.email,
+						From: env.NO_REPLY_EMAIL,
+						TemplateAlias: "event-wait-list",
+						TemplateModel: expect.objectContaining({
+							eventName: event.name,
+							eventStartAt: expect.any(String),
+						}),
+					}),
+				);
+			}
+
+			for (const user of shouldRemainOnWaitListUsers) {
+				const signUpAvailability = await eventService.getSignUpAvailability(
+					user.id,
+					event.id,
+				);
+				expect(signUpAvailability).toBe("ON_WAITLIST");
+			}
+		});
+	});
+});

--- a/src/services/events/__tests__/unit/events.test.ts
+++ b/src/services/events/__tests__/unit/events.test.ts
@@ -17,6 +17,7 @@ import {
 	type PermissionService,
 	type UserService,
 } from "../../service.js";
+import type { SignUpQueueType } from "../../worker.js";
 
 function setup() {
 	const permissionService = mockDeep<PermissionService>();
@@ -26,6 +27,7 @@ function setup() {
 		eventsRepository,
 		permissionService,
 		userService,
+		mockDeep<SignUpQueueType>(),
 	);
 	return { permissionService, eventsRepository, service, userService };
 }

--- a/src/services/events/worker.ts
+++ b/src/services/events/worker.ts
@@ -1,0 +1,107 @@
+import type { EventSignUp } from "@prisma/client";
+import type { Processor } from "bullmq";
+import type { Logger } from "pino";
+import { InvalidArgumentError } from "~/domain/errors.js";
+import type { Event } from "~/domain/events.js";
+import type { Queue } from "~/lib/bullmq/queue.js";
+import type { Worker } from "~/lib/bullmq/worker.js";
+import type { Result } from "~/lib/result.js";
+import type { Context } from "../context.js";
+import type { EmailQueueType } from "../mail/worker.js";
+
+type SignUpQueueDataType = { eventId: string };
+type SignUpQueueReturnType = Result<undefined>;
+type SignUpQueueNameType = "event-capacity-increased";
+
+type SignUpQueueType = Queue<
+	SignUpQueueDataType,
+	SignUpQueueReturnType,
+	SignUpQueueNameType
+>;
+
+type SignUpWorkerType = Worker<
+	SignUpQueueDataType,
+	SignUpQueueReturnType,
+	SignUpQueueNameType
+>;
+
+export type {
+	SignUpQueueDataType,
+	SignUpQueueNameType,
+	SignUpQueueReturnType,
+	SignUpQueueType,
+	SignUpWorkerType,
+};
+
+const SignUpQueueName = "sign-up" as const;
+
+type EventService = {
+	promoteFromWaitList(
+		ctx: Context,
+		eventId: string,
+	): Promise<EventSignUp | null>;
+	get(id: string): Promise<Event>;
+};
+
+const getSignUpWorkerHandler = ({
+	events,
+	emailQueue,
+	log,
+}: { events: EventService; emailQueue: EmailQueueType; log: Logger }): {
+	name: string;
+	handler: Processor<
+		SignUpQueueDataType,
+		SignUpQueueReturnType,
+		SignUpQueueNameType
+	>;
+} => {
+	return {
+		name: SignUpQueueName,
+		handler: async (job) => {
+			const { eventId } = job.data;
+			const event = await events.get(eventId);
+
+			switch (job.name) {
+				case "event-capacity-increased": {
+					if (event.signUpsEnabled) {
+						const maxAttempts = event.signUpDetails.remainingCapacity;
+						const newSignUps: EventSignUp[] = [];
+						for (let attempt = 0; attempt < maxAttempts; attempt++) {
+							const signUp = await events.promoteFromWaitList(
+								{ log, user: null },
+								eventId,
+							);
+							if (signUp !== null) {
+								newSignUps.push(signUp);
+							} else {
+								break;
+							}
+						}
+						await emailQueue.addBulk(
+							newSignUps.map((newSignUp) => {
+								return {
+									name: "send-email",
+									data: {
+										type: "event-wait-list-confirmation",
+										eventId: newSignUp.eventId,
+										recipientId: newSignUp.userId,
+									},
+								};
+							}),
+						);
+						return {
+							ok: true,
+							data: undefined,
+						};
+					}
+					return {
+						ok: false,
+						error: new InvalidArgumentError("Event is not accepting sign-ups"),
+					};
+				}
+			}
+		},
+	};
+};
+
+export { getSignUpWorkerHandler, SignUpQueueName };

--- a/src/services/products/worker.ts
+++ b/src/services/products/worker.ts
@@ -33,6 +33,8 @@ type ProductService = {
 	): Promise<Result<{ paymentAttempt: PaymentAttempt }>>;
 };
 
+const PaymentProcessingQueueName = "payment-processing" as const;
+
 function getPaymentProcessingHandler({
 	productService,
 	log,
@@ -40,7 +42,7 @@ function getPaymentProcessingHandler({
 	productService: ProductService;
 	log: Logger;
 }): {
-	name: string;
+	name: typeof PaymentProcessingQueueName;
 	handler: Processor<
 		PaymentProcessingDataType,
 		PaymentProcessingResultType,
@@ -96,12 +98,12 @@ function getPaymentProcessingHandler({
 	};
 
 	return {
-		name: "payment-processing",
+		name: PaymentProcessingQueueName,
 		handler: processor,
 	};
 }
 
-export { getPaymentProcessingHandler };
+export { getPaymentProcessingHandler, PaymentProcessingQueueName };
 export type {
 	PaymentProcessingDataType,
 	PaymentProcessingNameType,

--- a/src/services/users/service.ts
+++ b/src/services/users/service.ts
@@ -228,8 +228,9 @@ export class UserService {
 	async create(data: Prisma.UserCreateInput): Promise<User> {
 		this.validateUser(data);
 		const user = await this.usersRepository.create(data);
-		await this.emailQueue.add("welcome", {
+		await this.emailQueue.add("send-email", {
 			recipientId: user.id,
+			type: "user-registration",
 		});
 		return user;
 	}


### PR DESCRIPTION
### Changes
- Add a sign up worker and queue to handle the promotion of users from the wait list after a user retracts a confirmed sign up
- Add email notifications when a user is promoted
- Add integration and stress tests