### PR TITLE
:recycle: refactor(mail): clean up service, add templates

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,6 @@
 CORS_CREDENTIALS=true
 CORS_ORIGINS=http://localhost:3000,https://sandbox.embed.apollographql.com,https://studio.apollographql.com/sandbox/explorer
+CONTACT_EMAIL=kontakt@rubberdok.no
 DATABASE_CONNECTION_STRING=postgresql://postgres:postgres@localhost:5433?schema=public
 FEIDE_BASE_URL=https://auth.dataporten.no
 FEIDE_GROUPS_API=https://groups-api.dataporten.no/groups/me/groups

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
 CORS_CREDENTIALS=true
 CORS_ORIGINS=http://localhost:3000
+CONTACT_EMAIL=kontakt@rubberdok.no
 DATABASE_CONNECTION_STRING="postgresql://postgres:postgres@localhost:5433?schema=test"
 FEIDE_BASE_URL=https://auth.dataporten.no
 FEIDE_GROUPS_API=https://groups-api.dataporten.no/groups/me/groups

--- a/.env.worker.development
+++ b/.env.worker.development
@@ -1,5 +1,6 @@
 CORS_CREDENTIALS=true
 CORS_ORIGINS=http://localhost:3000,https://sandbox.embed.apollographql.com,https://studio.apollographql.com/sandbox/explorer
+CONTACT_EMAIL=kontakt@rubberdok.no
 DATABASE_CONNECTION_STRING=postgresql://postgres:postgres@localhost:5433?schema=public
 FEIDE_BASE_URL=https://auth.dataporten.no
 FEIDE_GROUPS_API=https://groups-api.dataporten.no/groups/me/groups

--- a/infrastructure/server/environments/production/terraform.tfvars
+++ b/infrastructure/server/environments/production/terraform.tfvars
@@ -76,6 +76,10 @@ environment_variables = [
   {
     name  = "VIPPS_TEST_MODE",
     value = "true"
+  },
+  {
+    name  = "CONTACT_EMAIL",
+    value = "kontakt@rubberdok.no"
   }
 ]
 

--- a/src/__tests__/dependencies-factory.ts
+++ b/src/__tests__/dependencies-factory.ts
@@ -39,7 +39,14 @@ export function makeTestServices(
 	const listingRepository = new ListingRepository(database);
 	const productRepository = new ProductRepository(database);
 
-	const mailService = new MailService(postmark, env.NO_REPLY_EMAIL);
+	const mailService = new MailService(postmark, {
+		noReplyEmail: env.NO_REPLY_EMAIL,
+		contactMail: env.CONTACT_EMAIL,
+		companyName: env.COMPANY_NAME,
+		parentCompany: env.PARENT_COMPANY,
+		productName: env.PRODUCT_NAME,
+		websiteUrl: env.CLIENT_URL,
+	});
 	const permissionService = new PermissionService(
 		memberRepository,
 		userRepository,

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,15 @@ const envVarsSchema = z.object({
 	VIPPS_DEFAULT_CLIENT_SECRET: z.string().optional(),
 	VIPPS_DEFAULT_MERCHANT_SERIAL_NUMBER: z.string().optional(),
 	VIPPS_DEFAULT_SUBSCRIPTION_KEY: z.string().optional(),
+	CLIENT_URL: z.string().default("https://indokntnu.no"),
+	COMPANY_NAME: z.string().default("Rubberdøk"),
+	PARENT_COMPANY: z
+		.string()
+		.default(
+			"Foreningen for Studentene ved Industriell Økonomi og Teknologiledelse",
+		),
+	PRODUCT_NAME: z.string().default("Indøk NTNU"),
+	CONTACT_EMAIL: z.string().email(),
 });
 
 export const env = envVarsSchema.parse(process.env);

--- a/src/lib/bullmq/worker.ts
+++ b/src/lib/bullmq/worker.ts
@@ -225,7 +225,14 @@ export async function initWorkers(): Promise<{
 			permissionService,
 			instance.queues?.email,
 		);
-		const mailService = new MailService(postmark, env.NO_REPLY_EMAIL);
+		const mailService = new MailService(postmark, {
+			noReplyEmail: env.NO_REPLY_EMAIL,
+			contactMail: env.CONTACT_EMAIL,
+			companyName: env.COMPANY_NAME,
+			parentCompany: env.PARENT_COMPANY,
+			productName: env.PRODUCT_NAME,
+			websiteUrl: env.CLIENT_URL,
+		});
 
 		if (!instance.queues?.[PaymentProcessingQueueName]) {
 			throw new InternalServerError("Payment processing queue not initialized");

--- a/src/lib/postmark.ts
+++ b/src/lib/postmark.ts
@@ -1,54 +1,6 @@
-import { ServerClient, type TemplatedMessage } from "postmark";
+import { ServerClient } from "postmark";
 import { env } from "~/config.js";
 
 export default new ServerClient(env.POSTMARK_API_TOKEN);
 
-type Modify<M, N> = Omit<M, Extract<keyof M, keyof N>> & N;
-
 export type IMailClient = ServerClient;
-
-export const TemplateAlias = {
-	EVENT_WAIT_LIST: "event-wait-list",
-	CABIN_BOOKING_RECEIPT: "cabin-booking-receipt",
-	WELCOME: "welcome",
-} as const;
-
-type CabinBookingReceipt = {
-	firstName: string;
-	lastName: string;
-};
-
-type Model = {
-	[TemplateAlias.EVENT_WAIT_LIST]: {
-		subject: string;
-		eventName: string;
-		eventStartAt: string;
-		location: string;
-	};
-	[TemplateAlias.CABIN_BOOKING_RECEIPT]: CabinBookingReceipt;
-	[TemplateAlias.WELCOME]: {
-		firstName: string;
-		lastName: string;
-	};
-};
-
-export type EmailContent = Modify<
-	TemplatedMessage,
-	{
-		From?: string;
-	}
-> &
-	(
-		| {
-				TemplateAlias: typeof TemplateAlias.EVENT_WAIT_LIST;
-				TemplateModel: Model[typeof TemplateAlias.EVENT_WAIT_LIST];
-		  }
-		| {
-				TemplateAlias: typeof TemplateAlias.CABIN_BOOKING_RECEIPT;
-				TemplateModel: Model[typeof TemplateAlias.CABIN_BOOKING_RECEIPT];
-		  }
-		| {
-				TemplateAlias: typeof TemplateAlias.WELCOME;
-				TemplateModel: Model[typeof TemplateAlias.WELCOME];
-		  }
-	);

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -350,7 +350,14 @@ async function registerServices(
 	const listingRepository = new ListingRepository(database);
 	const productRepository = new ProductRepository(database);
 
-	const mailService = new MailService(postmark, env.NO_REPLY_EMAIL);
+	const mailService = new MailService(postmark, {
+		companyName: env.COMPANY_NAME,
+		contactMail: env.CONTACT_EMAIL,
+		noReplyEmail: env.NO_REPLY_EMAIL,
+		parentCompany: env.PARENT_COMPANY,
+		productName: env.PRODUCT_NAME,
+		websiteUrl: env.CLIENT_URL,
+	});
 	const permissionService = new PermissionService(
 		memberRepository,
 		userRepository,

--- a/src/services/cabins/__tests__/unit/new-booking-email.test.ts
+++ b/src/services/cabins/__tests__/unit/new-booking-email.test.ts
@@ -5,7 +5,6 @@ import dayjs from "dayjs";
 import { type DeepMockProxy, mockDeep } from "jest-mock-extended";
 import { DateTime } from "luxon";
 import { BookingStatus } from "~/domain/cabins.js";
-import { TemplateAlias } from "~/lib/postmark.js";
 import {
 	type BookingData,
 	type CabinRepository,
@@ -41,8 +40,9 @@ describe("newBooking", () => {
 		name: string;
 		input: BookingData;
 		expectedConfirmationEmail: {
-			firstName: string;
-			lastName: string;
+			booking: {
+				price: string;
+			};
 		};
 	}
 
@@ -50,10 +50,11 @@ describe("newBooking", () => {
 		{
 			name: "should send a booking confirmation email",
 			input: validBooking,
-			expectedConfirmationEmail: {
-				firstName: validBooking.firstName,
-				lastName: validBooking.lastName,
-			},
+			expectedConfirmationEmail: expect.objectContaining({
+				booking: expect.objectContaining({
+					price: expect.any(String),
+				}),
+			}),
 		},
 	];
 
@@ -86,8 +87,9 @@ describe("newBooking", () => {
 		await cabinService.newBooking(input);
 		expect(repo.createBooking).toHaveBeenCalledWith(input);
 		expect(mockMailService.send).toHaveBeenCalledWith({
-			TemplateAlias: TemplateAlias.CABIN_BOOKING_RECEIPT,
-			TemplateModel: expectedConfirmationEmail,
+			templateAlias: "cabin-booking-receipt",
+			content: expectedConfirmationEmail,
+			to: input.email,
 		});
 	});
 });

--- a/src/services/cabins/service.ts
+++ b/src/services/cabins/service.ts
@@ -15,7 +15,7 @@ import {
 	NotFoundError,
 	PermissionDeniedError,
 } from "~/domain/errors.js";
-import { type EmailContent, TemplateAlias } from "~/lib/postmark.js";
+import type { MailContent } from "../mail/index.js";
 
 export interface BookingData {
 	email: string;
@@ -76,7 +76,7 @@ export interface PermissionService {
 }
 
 export interface IMailService {
-	send(template: EmailContent): Promise<MessageSendingResponse>;
+	send(data: MailContent): Promise<MessageSendingResponse>;
 }
 
 export class CabinService {
@@ -242,10 +242,12 @@ export class CabinService {
 
 	private sendBookingConfirmation(booking: Booking) {
 		return this.mailService.send({
-			TemplateAlias: TemplateAlias.CABIN_BOOKING_RECEIPT,
-			TemplateModel: {
-				firstName: booking.firstName,
-				lastName: booking.lastName,
+			to: booking.email,
+			templateAlias: "cabin-booking-receipt",
+			content: {
+				booking: {
+					price: "",
+				},
 			},
 		});
 	}

--- a/src/services/events/__tests__/integration/sign-off-waitlist-promotion.test.ts
+++ b/src/services/events/__tests__/integration/sign-off-waitlist-promotion.test.ts
@@ -247,10 +247,10 @@ describe("EventService", () => {
 			expect(promotedSignUp).toBe("CONFIRMED");
 			expect(mailClient.sendEmailWithTemplate).toHaveBeenCalledWith(
 				expect.objectContaining({
-					to: waitListUser.email,
-					from: env.NO_REPLY_EMAIL,
-					templateAlias: "event-wait-list",
-					content: expect.objectContaining({
+					To: waitListUser.email,
+					From: env.NO_REPLY_EMAIL,
+					TemplateAlias: "event-wait-list",
+					TemplateModel: expect.objectContaining({
 						event: expect.objectContaining({
 							name: event.name,
 							startAt: expect.any(String),
@@ -419,10 +419,10 @@ describe("EventService", () => {
 				expect(promotedSignUp).toBe("CONFIRMED");
 				expect(mailClient.sendEmailWithTemplate).toHaveBeenCalledWith(
 					expect.objectContaining({
-						to: user.email,
-						from: env.NO_REPLY_EMAIL,
-						templateAlias: "event-wait-list",
-						content: expect.objectContaining({
+						To: user.email,
+						From: env.NO_REPLY_EMAIL,
+						TemplateAlias: "event-wait-list",
+						TemplateModel: expect.objectContaining({
 							event: expect.objectContaining({
 								name: event.name,
 								startAt: expect.any(String),

--- a/src/services/events/__tests__/integration/sign-off-waitlist-promotion.test.ts
+++ b/src/services/events/__tests__/integration/sign-off-waitlist-promotion.test.ts
@@ -84,7 +84,14 @@ describe("EventService", () => {
 			memberRepository,
 			permissionService,
 		);
-		const mailService = new MailService(mailClient, env.NO_REPLY_EMAIL);
+		const mailService = new MailService(mailClient, {
+			companyName: "test",
+			contactMail: faker.internet.email(),
+			noReplyEmail: env.NO_REPLY_EMAIL,
+			productName: "test",
+			parentCompany: "test",
+			websiteUrl: env.CLIENT_URL,
+		});
 
 		const emailWorkerHandler = getEmailHandler({
 			eventService,
@@ -240,12 +247,15 @@ describe("EventService", () => {
 			expect(promotedSignUp).toBe("CONFIRMED");
 			expect(mailClient.sendEmailWithTemplate).toHaveBeenCalledWith(
 				expect.objectContaining({
-					To: waitListUser.email,
-					From: env.NO_REPLY_EMAIL,
-					TemplateAlias: "event-wait-list",
-					TemplateModel: expect.objectContaining({
-						eventName: event.name,
-						eventStartAt: expect.any(String),
+					to: waitListUser.email,
+					from: env.NO_REPLY_EMAIL,
+					templateAlias: "event-wait-list",
+					content: expect.objectContaining({
+						event: expect.objectContaining({
+							name: event.name,
+							startAt: expect.any(String),
+							url: `${env.CLIENT_URL}/events/${event.id}`,
+						}),
 					}),
 				}),
 			);
@@ -409,12 +419,15 @@ describe("EventService", () => {
 				expect(promotedSignUp).toBe("CONFIRMED");
 				expect(mailClient.sendEmailWithTemplate).toHaveBeenCalledWith(
 					expect.objectContaining({
-						To: user.email,
-						From: env.NO_REPLY_EMAIL,
-						TemplateAlias: "event-wait-list",
-						TemplateModel: expect.objectContaining({
-							eventName: event.name,
-							eventStartAt: expect.any(String),
+						to: user.email,
+						from: env.NO_REPLY_EMAIL,
+						templateAlias: "event-wait-list",
+						content: expect.objectContaining({
+							event: expect.objectContaining({
+								name: event.name,
+								startAt: expect.any(String),
+								url: `${env.CLIENT_URL}/events/${event.id}`,
+							}),
 						}),
 					}),
 				);

--- a/src/services/mail/index.ts
+++ b/src/services/mail/index.ts
@@ -1,15 +1,92 @@
-import type { EmailContent, IMailClient } from "~/lib/postmark.js";
+import { merge } from "lodash-es";
+import type { IMailClient } from "~/lib/postmark.js";
+
+type LayoutContent = {
+	websiteUrl: string;
+	productName: string;
+	parentCompany: string;
+	companyName: string;
+	contactMail: string;
+};
+
+type BaseMailContent<
+	TAlias extends string,
+	TData extends Record<string, object>,
+> = {
+	to: string;
+	from?: string;
+	templateAlias: TAlias;
+	content: TData & Partial<LayoutContent>;
+};
+
+type EventWaitlistNotification = BaseMailContent<
+	"event-wait-list",
+	{
+		event: {
+			name: string;
+			startAt: string;
+			location?: string;
+			price?: string;
+			url: string;
+		};
+	}
+>;
+
+type CabinBookingReceipt = BaseMailContent<
+	"cabin-booking-receipt",
+	{
+		booking: {
+			price: string;
+		};
+	}
+>;
+
+type UserRegistration = BaseMailContent<
+	"user-registration",
+	{
+		user: {
+			firstName: string;
+			lastName: string;
+			studyProgram?: string;
+		};
+	}
+>;
+
+export type MailContent =
+	| EventWaitlistNotification
+	| CabinBookingReceipt
+	| UserRegistration;
 
 export class MailService {
 	constructor(
 		private client: IMailClient,
-		private noReplyEmail: string,
+		private defaults: {
+			companyName: string;
+			noReplyEmail: string;
+			productName: string;
+			parentCompany: string;
+			contactMail: string;
+			websiteUrl: string;
+		},
 	) {}
 
-	send(template: EmailContent) {
+	send(data: MailContent) {
+		const { to, from, content, templateAlias } = data;
+		const defaultContent: LayoutContent = {
+			companyName: this.defaults.companyName,
+			parentCompany: this.defaults.parentCompany,
+			contactMail: this.defaults.contactMail,
+			productName: this.defaults.productName,
+			websiteUrl: this.defaults.websiteUrl,
+		};
+
+		const contentWithDefaults = merge({}, defaultContent, content);
+
 		return this.client.sendEmailWithTemplate({
-			...template,
-			From: template.From ?? this.noReplyEmail,
+			To: to,
+			From: from ?? this.defaults.noReplyEmail,
+			TemplateAlias: templateAlias,
+			TemplateModel: contentWithDefaults,
 		});
 	}
 }


### PR DESCRIPTION
### Changes
- Remove hacky type modification in favor of more straight-forward type declarations
- Add variables that are used by the layout
- Minor changes to the initialization of the mail service