### PR TITLE
:recycle: refactor: use mail service instead of queue directly

### DIFF
--- a/src/__tests__/dependencies-factory.ts
+++ b/src/__tests__/dependencies-factory.ts
@@ -17,7 +17,7 @@ import { CabinService } from "~/services/cabins/service.js";
 import { EventService } from "~/services/events/service.js";
 import type { SignUpQueueType } from "~/services/events/worker.js";
 import { ListingService } from "~/services/listings/service.js";
-import { MailService } from "~/services/mail/index.js";
+import { buildMailService } from "~/services/mail/index.js";
 import type { EmailQueueType } from "~/services/mail/worker.js";
 import { OrganizationService } from "~/services/organizations/service.js";
 import { PermissionService } from "~/services/permissions/service.js";
@@ -39,14 +39,20 @@ export function makeTestServices(
 	const listingRepository = new ListingRepository(database);
 	const productRepository = new ProductRepository(database);
 
-	const mailService = new MailService(mockDeep<ServerClient>(), {
-		noReplyEmail: env.NO_REPLY_EMAIL,
-		contactMail: env.CONTACT_EMAIL,
-		companyName: env.COMPANY_NAME,
-		parentCompany: env.PARENT_COMPANY,
-		productName: env.PRODUCT_NAME,
-		websiteUrl: env.CLIENT_URL,
-	});
+	const mailService = buildMailService(
+		{
+			emailClient: mockDeep<ServerClient>(),
+			emailQueue: mockDeep<EmailQueueType>(),
+		},
+		{
+			noReplyEmail: env.NO_REPLY_EMAIL,
+			contactMail: env.CONTACT_EMAIL,
+			companyName: env.COMPANY_NAME,
+			parentCompany: env.PARENT_COMPANY,
+			productName: env.PRODUCT_NAME,
+			websiteUrl: env.CLIENT_URL,
+		},
+	);
 	const permissionService = new PermissionService(
 		memberRepository,
 		userRepository,
@@ -70,7 +76,7 @@ export function makeTestServices(
 	const userService = new UserService(
 		userRepository,
 		permissionService,
-		mockDeep<EmailQueueType>(),
+		mailService,
 	);
 	const eventService = new EventService(
 		eventRepository,

--- a/src/lib/postmark.ts
+++ b/src/lib/postmark.ts
@@ -1,13 +1,27 @@
-import { mockDeep } from "jest-mock-extended";
-import { ServerClient } from "postmark";
+import { ServerClient, type TemplatedMessage } from "postmark";
+import type { MessageSendingResponse } from "postmark/dist/client/models/index.js";
 
-function postmark(apiToken: string, options?: { useTestMode: boolean }) {
+type EmailClient = {
+	sendEmailWithTemplate: (
+		template: TemplatedMessage,
+	) => Promise<undefined | MessageSendingResponse>;
+};
+
+function postmark(
+	apiToken: string,
+	options?: { useTestMode: boolean },
+): EmailClient {
 	if (options?.useTestMode) {
-		return mockDeep<ServerClient>();
+		return {
+			sendEmailWithTemplate(data) {
+				console.log("Email sent with test mode:", data);
+				return Promise.resolve(undefined);
+			},
+		};
 	}
 	return new ServerClient(apiToken);
 }
 
 export { postmark };
 
-export type IMailClient = ServerClient;
+export type IMailClient = EmailClient;

--- a/src/services/cabins/__tests__/unit/booking-contact.test.ts
+++ b/src/services/cabins/__tests__/unit/booking-contact.test.ts
@@ -8,7 +8,7 @@ import {
 import {
 	type CabinRepository,
 	CabinService,
-	type IMailService,
+	type MailService,
 	type PermissionService,
 } from "../../service.js";
 
@@ -16,12 +16,12 @@ describe("CabinService", () => {
 	let cabinService: CabinService;
 	let cabinRepository: DeepMockProxy<CabinRepository>;
 	let permissionService: DeepMockProxy<PermissionService>;
-	let mailService: DeepMockProxy<IMailService>;
+	let mailService: DeepMockProxy<MailService>;
 
 	beforeAll(() => {
 		cabinRepository = mockDeep<CabinRepository>();
 		permissionService = mockDeep<PermissionService>();
-		mailService = mockDeep<IMailService>();
+		mailService = mockDeep<MailService>();
 		cabinService = new CabinService(
 			cabinRepository,
 			mailService,

--- a/src/services/cabins/__tests__/unit/booking-semester.test.ts
+++ b/src/services/cabins/__tests__/unit/booking-semester.test.ts
@@ -6,7 +6,7 @@ import { NotFoundError, PermissionDeniedError } from "~/domain/errors.js";
 import {
 	type CabinRepository,
 	CabinService,
-	type IMailService,
+	type MailService,
 	type PermissionService,
 } from "../../service.js";
 
@@ -20,7 +20,7 @@ describe("CabinService", () => {
 		permissionSerivce = mockDeep<PermissionService>();
 		cabinService = new CabinService(
 			cabinRepository,
-			mockDeep<IMailService>(),
+			mockDeep<MailService>(),
 			permissionSerivce,
 		);
 	});

--- a/src/services/cabins/__tests__/unit/new-booking-email.test.ts
+++ b/src/services/cabins/__tests__/unit/new-booking-email.test.ts
@@ -9,7 +9,7 @@ import {
 	type BookingData,
 	type CabinRepository,
 	CabinService,
-	type IMailService,
+	type MailService,
 	type PermissionService,
 } from "../../service.js";
 
@@ -24,13 +24,13 @@ const validBooking: BookingData = {
 };
 
 let repo: DeepMockProxy<CabinRepository>;
-let mockMailService: DeepMockProxy<IMailService>;
+let mockMailService: DeepMockProxy<MailService>;
 let cabinService: CabinService;
 let permissionService: DeepMockProxy<PermissionService>;
 
 beforeAll(() => {
 	repo = mockDeep<CabinRepository>();
-	mockMailService = mockDeep<IMailService>();
+	mockMailService = mockDeep<MailService>();
 	permissionService = mockDeep<PermissionService>();
 	cabinService = new CabinService(repo, mockMailService, permissionService);
 });
@@ -86,10 +86,9 @@ describe("newBooking", () => {
 
 		await cabinService.newBooking(input);
 		expect(repo.createBooking).toHaveBeenCalledWith(input);
-		expect(mockMailService.send).toHaveBeenCalledWith({
-			templateAlias: "cabin-booking-receipt",
-			content: expectedConfirmationEmail,
-			to: input.email,
+		expect(mockMailService.sendAsync).toHaveBeenCalledWith({
+			type: "cabin-booking-receipt",
+			bookingId: expect.any(String),
 		});
 	});
 });

--- a/src/services/cabins/__tests__/unit/new-booking.test.ts
+++ b/src/services/cabins/__tests__/unit/new-booking.test.ts
@@ -3,24 +3,23 @@ import { type Booking, type BookingSemester, Semester } from "@prisma/client";
 import { type DeepMockProxy, mock, mockDeep } from "jest-mock-extended";
 import { merge } from "lodash-es";
 import { DateTime } from "luxon";
-import type { MessageSendingResponse } from "postmark/dist/client/models/index.js";
 import { InvalidArgumentError } from "~/domain/errors.js";
 import {
 	type BookingData,
 	type CabinRepository,
 	CabinService,
-	type IMailService,
+	type MailService,
 	type PermissionService,
 } from "../../service.js";
 
 describe("CabinService", () => {
 	let cabinService: CabinService;
 	let cabinRepository: DeepMockProxy<CabinRepository>;
-	let mailService: DeepMockProxy<IMailService>;
+	let mailService: DeepMockProxy<MailService>;
 
 	beforeAll(() => {
 		cabinRepository = mockDeep<CabinRepository>();
-		mailService = mockDeep<IMailService>();
+		mailService = mockDeep<MailService>();
 		cabinService = new CabinService(
 			cabinRepository,
 			mailService,
@@ -578,9 +577,7 @@ describe("CabinService", () => {
 					},
 				);
 				cabinRepository.createBooking.mockResolvedValueOnce(mock<Booking>());
-				mailService.send.mockImplementationOnce(() =>
-					Promise.resolve(mock<MessageSendingResponse>()),
-				);
+				mailService.sendAsync.mockResolvedValue();
 
 				/**
 				 * Act

--- a/src/services/cabins/__tests__/unit/update.test.ts
+++ b/src/services/cabins/__tests__/unit/update.test.ts
@@ -9,19 +9,19 @@ import {
 import {
 	type CabinRepository,
 	CabinService,
-	type IMailService,
+	type MailService,
 	type PermissionService,
 } from "../../service.js";
 
 describe("CabinService", () => {
 	let cabinRepository: DeepMockProxy<CabinRepository>;
-	let mailService: DeepMockProxy<IMailService>;
+	let mailService: DeepMockProxy<MailService>;
 	let permissionService: DeepMockProxy<PermissionService>;
 	let cabinService: CabinService;
 
 	beforeAll(() => {
 		cabinRepository = mockDeep<CabinRepository>();
-		mailService = mockDeep<IMailService>();
+		mailService = mockDeep<MailService>();
 		permissionService = mockDeep<PermissionService>();
 		cabinService = new CabinService(
 			cabinRepository,

--- a/src/services/users/__tests__/unit/study-program.test.ts
+++ b/src/services/users/__tests__/unit/study-program.test.ts
@@ -1,8 +1,8 @@
 import { faker } from "@faker-js/faker";
 import { type DeepMockProxy, mockDeep } from "jest-mock-extended";
 import { InvalidArgumentError } from "~/domain/errors.js";
-import type { EmailQueueType } from "~/services/mail/worker.js";
 import {
+	type MailService,
 	type PermissionService,
 	type UserRepository,
 	UserService,
@@ -12,14 +12,16 @@ describe("UserService", () => {
 	let userService: UserService;
 	let permissionService: DeepMockProxy<PermissionService>;
 	let userRepository: DeepMockProxy<UserRepository>;
+	let mailService: DeepMockProxy<MailService>;
 
 	beforeAll(() => {
 		userRepository = mockDeep<UserRepository>();
 		permissionService = mockDeep<PermissionService>();
+		mailService = mockDeep<MailService>();
 		userService = new UserService(
 			userRepository,
 			permissionService,
-			mockDeep<EmailQueueType>(),
+			mailService,
 		);
 	});
 

--- a/src/services/users/__tests__/unit/update.test.ts
+++ b/src/services/users/__tests__/unit/update.test.ts
@@ -4,8 +4,8 @@ import { DateTime } from "luxon";
 import { PermissionDeniedError } from "~/domain/errors.js";
 import type { User } from "~/domain/users.js";
 import { makeMockContext } from "~/services/context.js";
-import type { EmailQueueType } from "~/services/mail/worker.js";
 import {
+	type MailService,
 	type PermissionService,
 	type UserRepository,
 	UserService,
@@ -15,14 +15,16 @@ describe("UserService", () => {
 	let userService: UserService;
 	let permissionService: DeepMockProxy<PermissionService>;
 	let userRepository: DeepMockProxy<UserRepository>;
+	let mailService: DeepMockProxy<MailService>;
 
 	beforeAll(() => {
 		userRepository = mockDeep<UserRepository>();
 		permissionService = mockDeep<PermissionService>();
+		mailService = mockDeep<MailService>();
 		userService = new UserService(
 			userRepository,
 			permissionService,
-			mockDeep<EmailQueueType>(),
+			mailService,
 		);
 	});
 

--- a/src/services/users/__tests__/unit/user.test.ts
+++ b/src/services/users/__tests__/unit/user.test.ts
@@ -3,8 +3,8 @@ import { jest } from "@jest/globals";
 import dayjs from "dayjs";
 import { type DeepMockProxy, mock, mockDeep } from "jest-mock-extended";
 import type { User } from "~/domain/users.js";
-import type { EmailQueueType } from "~/services/mail/worker.js";
 import {
+	type MailService,
 	type PermissionService,
 	type UserRepository,
 	UserService,
@@ -15,15 +15,13 @@ const time = new Date(`${dayjs().year() + 1}-01-01`);
 let service: UserService;
 let repo: DeepMockProxy<UserRepository>;
 let permissionService: DeepMockProxy<PermissionService>;
+let mailService: DeepMockProxy<MailService>;
 
 beforeAll(() => {
 	repo = mockDeep<UserRepository>();
 	permissionService = mockDeep<PermissionService>();
-	service = new UserService(
-		repo,
-		permissionService,
-		mockDeep<EmailQueueType>(),
-	);
+	mailService = mockDeep<MailService>();
+	service = new UserService(repo, permissionService, mailService);
 
 	jest.useFakeTimers().setSystemTime(time);
 });


### PR DESCRIPTION
### Changes
- Send emails through MailService, which relies on queues under the hood.