### PR TITLE
:sparkles: feat(products): add queries for orders, payment attempts

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -545,7 +545,14 @@ enum OrderPaymentStatus {
 }
 
 input OrdersInput {
+  """Only get orders for the given product ID."""
   productId: ID
+
+  """
+  Only get orders for the given user ID. Requires super user status,
+  or the user ID to match the user ID of the order. Omit to default to
+  the current user.
+  """
   userId: ID
 }
 
@@ -607,8 +614,17 @@ enum PaymentAttemptState {
 }
 
 input PaymentAttemptsInput {
+  """Only get payment atttempts for the given order ID."""
   orderId: ID
+
+  """Only get payment attempts for the given product ID."""
   productId: ID
+
+  """
+  Only get payment attempts for the given user ID. Requires super user status,
+  or the user ID to match the user ID of the payment attempt. Omit to default to
+  the current user.
+  """
   userId: ID
 }
 
@@ -706,10 +722,20 @@ type Query {
   hasFeaturePermission(data: HasFeaturePermissionInput!): HasFeaturePermissionResponse!
   listing(data: ListingInput!): ListingResponse!
   listings: ListingsResponse!
+
+  """
+  Get orders, filtered by the given input. Unless the user is a super user, only
+  orders for the current user will be returned.
+  """
   orders(data: OrdersInput): OrdersResponse!
 
   """Get all organizations"""
   organizations: OrganizationsResponse
+
+  """
+  Get payment attempts, filtered by the given input. Unless the user is a super user, only
+  payment attempts for the current user will be returned.
+  """
   paymentAttempts(data: PaymentAttemptsInput): PaymentAttemptsResponse!
   products: ProductResponse!
   serverTime: ServerTimeResponse!

--- a/schema.graphql
+++ b/schema.graphql
@@ -314,7 +314,7 @@ input EventTicketData {
   """
   MerchantID is the ID for the merchant, this will be the recipient of the payments.
   """
-  merchantId: String!
+  merchantId: ID!
 
   """Price in øre, i.e. 100 = 1 NOK"""
   price: Int!
@@ -528,7 +528,30 @@ type NewBookingResponse {
 }
 
 type Order {
+  attempt: Int!
   id: ID!
+  paymentStatus: OrderPaymentStatus!
+  product: Product!
+  user: PrivateUser
+}
+
+enum OrderPaymentStatus {
+  CANCELLED
+  CAPTURED
+  CREATED
+  PENDING
+  REFUNDED
+  RESERVED
+}
+
+input OrdersInput {
+  productId: ID
+  userId: ID
+}
+
+type OrdersResponse {
+  orders: [Order!]!
+  total: Int!
 }
 
 type Organization {
@@ -564,6 +587,34 @@ enum ParticipationStatus {
 
   """The user has signed up for the event, and then retracted their sign up"""
   RETRACTED
+}
+
+type PaymentAttempt {
+  id: ID!
+  inProgress: Boolean!
+  order: Order!
+  reference: String!
+  state: PaymentAttemptState!
+}
+
+enum PaymentAttemptState {
+  ABORTED
+  AUTHORIZED
+  CREATED
+  EXPIRED
+  FAILED
+  TERMINATED
+}
+
+input PaymentAttemptsInput {
+  orderId: ID
+  productId: ID
+  userId: ID
+}
+
+type PaymentAttemptsResponse {
+  paymentAttempts: [PaymentAttempt!]!
+  total: Int!
 }
 
 type Price {
@@ -655,9 +706,11 @@ type Query {
   hasFeaturePermission(data: HasFeaturePermissionInput!): HasFeaturePermissionResponse!
   listing(data: ListingInput!): ListingResponse!
   listings: ListingsResponse!
+  orders(data: OrdersInput): OrdersResponse!
 
   """Get all organizations"""
   organizations: OrganizationsResponse
+  paymentAttempts(data: PaymentAttemptsInput): PaymentAttemptsResponse!
   products: ProductResponse!
   serverTime: ServerTimeResponse!
   user: UserResponse!

--- a/src/domain/products.ts
+++ b/src/domain/products.ts
@@ -63,7 +63,7 @@ type OrderType = {
 	userId: string | null;
 };
 
-type PaymentAttempt = {
+type PaymentAttemptType = {
 	id: string;
 	orderId: string;
 	version: number;
@@ -152,12 +152,16 @@ const Order = {
 	},
 };
 
-export { PaymentAttemptFromDSO, Product, Order };
+const PaymentAttempt = {
+	fromDSO: PaymentAttemptFromDSO,
+};
+
+export { PaymentAttempt, Product, Order };
 export type {
 	MerchantType,
 	OrderPaymentStatus,
 	OrderType,
-	PaymentAttempt,
+	PaymentAttemptType,
 	PaymentAttemptState,
 	ProductType,
 };

--- a/src/graphql/__tests__/unit/index.test.ts
+++ b/src/graphql/__tests__/unit/index.test.ts
@@ -27,7 +27,7 @@ describe("GraphQL", () => {
         `),
 			},
 			{
-				contextValue: createMockContext({ userId: faker.string.uuid() }),
+				contextValue: createMockContext({ user: { id: faker.string.uuid() } }),
 			},
 		);
 

--- a/src/graphql/events/resolvers/Mutation/deleteEventCategory.unit.test.ts
+++ b/src/graphql/events/resolvers/Mutation/deleteEventCategory.unit.test.ts
@@ -17,7 +17,7 @@ describe("Event mutations", () => {
 			);
 
 			const contextValue = createMockContext({
-				userId: faker.string.uuid(),
+				user: { id: faker.string.uuid() },
 			});
 
 			const { errors } = await client.mutate(

--- a/src/graphql/events/schema.graphql
+++ b/src/graphql/events/schema.graphql
@@ -148,7 +148,7 @@ input EventTicketData {
   """
   MerchantID is the ID for the merchant, this will be the recipient of the payments.
   """
-  merchantId: String!
+  merchantId: ID!
 }
 
 input EventData {

--- a/src/graphql/organizations/__tests__/unit/organizations.test.ts
+++ b/src/graphql/organizations/__tests__/unit/organizations.test.ts
@@ -343,7 +343,7 @@ describe("OrganizationResolvers", () => {
 				 * 2. Create the mock context without a userId in session
 				 */
 				const { createMockContext, client } = createMockApolloServer();
-				const contextValue = createMockContext({ userId: undefined });
+				const contextValue = createMockContext({ user: null });
 
 				/**
 				 * Act

--- a/src/graphql/products/resolvers/Mutation/initiatePaymentAttempt.unit.test.ts
+++ b/src/graphql/products/resolvers/Mutation/initiatePaymentAttempt.unit.test.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { mock } from "jest-mock-extended";
 import { InternalServerError } from "~/domain/errors.js";
-import type { OrderType, PaymentAttempt } from "~/domain/products.js";
+import type { OrderType, PaymentAttemptType } from "~/domain/products.js";
 import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
 import { graphql } from "~/graphql/test-clients/unit/gql.js";
 
@@ -13,7 +13,7 @@ describe("Product mutations", () => {
 				ok: true,
 				data: {
 					order: mock<OrderType>(),
-					paymentAttempt: mock<PaymentAttempt>(),
+					paymentAttempt: mock<PaymentAttemptType>(),
 					pollingJob: mock(),
 					redirectUrl: faker.internet.url(),
 				},

--- a/src/graphql/products/resolvers/Order.ts
+++ b/src/graphql/products/resolvers/Order.ts
@@ -1,4 +1,19 @@
 import type { OrderResolvers } from "./../../types.generated.js";
 export const Order: OrderResolvers = {
 	/* Implement Order resolver logic here */
+	product: async (order, _args, ctx) => {
+		const getProductResult = await ctx.products.products.get(ctx, {
+			id: order.productId,
+		});
+		if (!getProductResult.ok) {
+			throw getProductResult.error;
+		}
+		return getProductResult.data.product;
+	},
+	user: (order, _args, ctx) => {
+		if (order.userId === ctx.user?.id) {
+			return ctx.user;
+		}
+		return null;
+	},
 };

--- a/src/graphql/products/resolvers/Order.ts
+++ b/src/graphql/products/resolvers/Order.ts
@@ -11,7 +11,7 @@ export const Order: OrderResolvers = {
 		return getProductResult.data.product;
 	},
 	user: (order, _args, ctx) => {
-		if (order.userId === ctx.user?.id) {
+		if (ctx.user && order.userId === ctx.user.id) {
 			return ctx.user;
 		}
 		return null;

--- a/src/graphql/products/resolvers/OrdersResponse.ts
+++ b/src/graphql/products/resolvers/OrdersResponse.ts
@@ -1,0 +1,4 @@
+import type { OrdersResponseResolvers } from "./../../types.generated.js";
+export const OrdersResponse: OrdersResponseResolvers = {
+	/* Implement OrdersResponse resolver logic here */
+};

--- a/src/graphql/products/resolvers/PaymentAttempt.ts
+++ b/src/graphql/products/resolvers/PaymentAttempt.ts
@@ -1,0 +1,13 @@
+import type { PaymentAttemptResolvers } from "./../../types.generated.js";
+export const PaymentAttempt: PaymentAttemptResolvers = {
+	/* Implement PaymentAttempt resolver logic here */
+	order: async (paymentAttempt, _args, ctx) => {
+		const getOrderResult = await ctx.products.orders.get(ctx, {
+			id: paymentAttempt.orderId,
+		});
+		if (!getOrderResult.ok) {
+			throw getOrderResult.error;
+		}
+		return getOrderResult.data.order;
+	},
+};

--- a/src/graphql/products/resolvers/PaymentAttemptsResponse.ts
+++ b/src/graphql/products/resolvers/PaymentAttemptsResponse.ts
@@ -1,0 +1,4 @@
+import type { PaymentAttemptsResponseResolvers } from "./../../types.generated.js";
+export const PaymentAttemptsResponse: PaymentAttemptsResponseResolvers = {
+	/* Implement PaymentAttemptsResponse resolver logic here */
+};

--- a/src/graphql/products/resolvers/Query/orders.ts
+++ b/src/graphql/products/resolvers/Query/orders.ts
@@ -1,0 +1,17 @@
+import type { QueryResolvers } from "./../../../types.generated.js";
+export const orders: NonNullable<QueryResolvers["orders"]> = async (
+	_parent,
+	{ data },
+	ctx,
+) => {
+	const findManyOrdersResult = await ctx.products.orders.findMany(ctx, data);
+
+	if (!findManyOrdersResult.ok) {
+		throw findManyOrdersResult.error;
+	}
+
+	return {
+		orders: findManyOrdersResult.data.orders,
+		total: findManyOrdersResult.data.total,
+	};
+};

--- a/src/graphql/products/resolvers/Query/orders.unit.test.ts
+++ b/src/graphql/products/resolvers/Query/orders.unit.test.ts
@@ -1,0 +1,138 @@
+import { faker } from "@faker-js/faker";
+import { mock } from "jest-mock-extended";
+import { InternalServerError } from "~/domain/errors.js";
+import type { OrderType, ProductType } from "~/domain/products.js";
+import type { User } from "~/domain/users.js";
+import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "~/graphql/test-clients/unit/gql.js";
+
+describe("Product queries", () => {
+	describe("#paymentAttempts", () => {
+		it("should return a list of orders with product and user: null if not making the request as that user", async () => {
+			const { productService, userService, client } = createMockApolloServer();
+			const user = mock<User>({ id: faker.string.uuid() });
+			productService.orders.findMany.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					orders: [
+						mock<OrderType>({ id: faker.string.uuid(), userId: user.id }),
+					],
+					total: 1,
+				},
+			});
+			productService.products.get.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					product: mock<ProductType>({ id: faker.string.uuid() }),
+				},
+			});
+			userService.get.mockResolvedValueOnce(user);
+
+			const { data, errors } = await client.query({
+				query: graphql(`
+                query orders {
+                    orders {
+                        orders {
+                            id
+                            product {
+                                id
+                            }
+                            user {
+                                id
+                            }
+                        }
+                        total
+                    }
+                }
+            `),
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data?.orders.orders).toEqual([
+				{
+					id: expect.any(String),
+					product: { id: expect.any(String) },
+					user: null,
+				},
+			]);
+		});
+
+		it("should return a list of orders with product and user if making the request as that user", async () => {
+			const { productService, userService, client, createMockContext } =
+				createMockApolloServer();
+			const user = mock<User>({ id: faker.string.uuid() });
+			productService.orders.findMany.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					orders: [
+						mock<OrderType>({ id: faker.string.uuid(), userId: user.id }),
+					],
+					total: 1,
+				},
+			});
+			productService.products.get.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					product: mock<ProductType>({ id: faker.string.uuid() }),
+				},
+			});
+			userService.get.mockResolvedValueOnce(user);
+
+			const { data, errors } = await client.query(
+				{
+					query: graphql(`
+                query orders {
+                    orders {
+                        orders {
+                            id
+                            product {
+                                id
+                            }
+                            user {
+                                id
+                            }
+                        }
+                        total
+                    }
+                }
+            `),
+				},
+				{
+					contextValue: createMockContext({ user }),
+				},
+			);
+
+			expect(errors).toBeUndefined();
+			expect(data?.orders.orders).toEqual([
+				{
+					id: expect.any(String),
+					product: { id: expect.any(String) },
+					user: { id: user.id },
+				},
+			]);
+		});
+
+		it("should throw if ok: false", async () => {
+			const { productService, client } = createMockApolloServer();
+			productService.orders.findMany.mockResolvedValueOnce({
+				ok: false,
+				error: new InternalServerError("Some error"),
+			});
+
+			const { errors } = await client.query({
+				query: graphql(`
+                query ordersShouldThrow {
+                    orders {
+                        orders {
+                            id
+                        }
+                        total
+                    }
+                }
+            `),
+			});
+
+			expect(errors).toBeDefined();
+		});
+	});
+});

--- a/src/graphql/products/resolvers/Query/paymentAttempts.ts
+++ b/src/graphql/products/resolvers/Query/paymentAttempts.ts
@@ -1,0 +1,17 @@
+import type { QueryResolvers } from "./../../../types.generated.js";
+export const paymentAttempts: NonNullable<QueryResolvers["paymentAttempts"]> =
+	async (_parent, { data }, ctx) => {
+		const findManyPaymentAttemptsResult = await ctx.products.payments.findMany(
+			ctx,
+			data,
+		);
+
+		if (!findManyPaymentAttemptsResult.ok) {
+			throw findManyPaymentAttemptsResult.error;
+		}
+
+		return {
+			paymentAttempts: findManyPaymentAttemptsResult.data.paymentAttempts,
+			total: findManyPaymentAttemptsResult.data.total,
+		};
+	};

--- a/src/graphql/products/resolvers/Query/paymentAttempts.unit.test.ts
+++ b/src/graphql/products/resolvers/Query/paymentAttempts.unit.test.ts
@@ -1,0 +1,116 @@
+import { faker } from "@faker-js/faker";
+import { mock } from "jest-mock-extended";
+import { InternalServerError } from "~/domain/errors.js";
+import type { OrderType, PaymentAttemptType } from "~/domain/products.js";
+import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "~/graphql/test-clients/unit/gql.js";
+
+describe("Product queries", () => {
+	describe("#paymentAttempts", () => {
+		it("should return a list of paymentAttempts with orders", async () => {
+			const { productService, client } = createMockApolloServer();
+			productService.payments.findMany.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					paymentAttempts: [
+						mock<PaymentAttemptType>({ id: faker.string.uuid() }),
+					],
+					total: 1,
+				},
+			});
+			productService.orders.get.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					order: mock<OrderType>({ id: faker.string.uuid() }),
+				},
+			});
+
+			const { data, errors } = await client.query({
+				query: graphql(`
+                query paymentAttempts {
+                    paymentAttempts {
+                        paymentAttempts {
+                            id
+                            order {
+                                id
+                            }
+                        }
+                        total
+                    }
+                }
+            `),
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data?.paymentAttempts.paymentAttempts).toEqual([
+				{ id: expect.any(String), order: { id: expect.any(String) } },
+			]);
+		});
+
+		it("should return a list of paymentAttempts with orders", async () => {
+			const { productService, client } = createMockApolloServer();
+			productService.payments.findMany.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					paymentAttempts: [
+						mock<PaymentAttemptType>({ id: faker.string.uuid() }),
+					],
+					total: 1,
+				},
+			});
+			productService.orders.get.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					order: mock<OrderType>({ id: faker.string.uuid() }),
+				},
+			});
+
+			const { data, errors } = await client.query({
+				query: graphql(`
+                query paymentAttempts {
+                    paymentAttempts {
+                        paymentAttempts {
+                            id
+                            order {
+                                id
+                            }
+                        }
+                        total
+                    }
+                }
+            `),
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data?.paymentAttempts.paymentAttempts).toEqual([
+				{ id: expect.any(String), order: { id: expect.any(String) } },
+			]);
+		});
+
+		it("should throw if ok: false", async () => {
+			const { productService, client } = createMockApolloServer();
+			productService.payments.findMany.mockResolvedValueOnce({
+				ok: false,
+				error: new InternalServerError("Some error"),
+			});
+
+			const { errors } = await client.query({
+				query: graphql(`
+                query paymentAttempts {
+                    paymentAttempts {
+                        paymentAttempts {
+                            id
+                            order {
+                                id
+                            }
+                        }
+                        total
+                    }
+                }
+            `),
+			});
+
+			expect(errors).toBeDefined();
+		});
+	});
+});

--- a/src/graphql/products/schema.graphql
+++ b/src/graphql/products/schema.graphql
@@ -12,9 +12,21 @@ type InitiatePaymentAttemptResponse {
     redirectUrl: String!
 }
 
+enum OrderPaymentStatus {
+    PENDING
+    CREATED
+    CAPTURED
+    REFUNDED
+    CANCELLED
+    RESERVED
+}
 
 type Order {
     id: ID!
+    product: Product!
+    user: PrivateUser
+    attempt: Int!
+    paymentStatus: OrderPaymentStatus!
 }
 
 input CreateOrderInput {
@@ -87,6 +99,45 @@ type ProductResponse {
     total: Int!
 }
 
+type OrdersResponse {
+    orders: [Order!]!
+    total: Int!
+}
+
+enum PaymentAttemptState {
+    CREATED
+    AUTHORIZED
+    FAILED
+    TERMINATED
+    EXPIRED
+    ABORTED
+}
+
+type PaymentAttempt {
+    id: ID!
+    reference: String!
+    inProgress: Boolean!
+    state: PaymentAttemptState!
+    order: Order!
+
+}
+
+type PaymentAttemptsResponse {
+    paymentAttempts: [PaymentAttempt!]!
+    total: Int!
+}
+
+input OrdersInput {
+    userId: ID
+    productId: ID
+}
+
+input PaymentAttemptsInput {
+    userId: ID
+    orderId: ID
+    productId: ID
+}
+
 type Mutation {
     """
     Initiates a payment attempt for the given order.
@@ -104,7 +155,8 @@ type Mutation {
 }
 
 
-
 type Query {
     products: ProductResponse!
+    orders(data: OrdersInput): OrdersResponse!
+    paymentAttempts(data: PaymentAttemptsInput): PaymentAttemptsResponse!
 }

--- a/src/graphql/products/schema.graphql
+++ b/src/graphql/products/schema.graphql
@@ -128,13 +128,32 @@ type PaymentAttemptsResponse {
 }
 
 input OrdersInput {
+    """
+    Only get orders for the given user ID. Requires super user status,
+    or the user ID to match the user ID of the order. Omit to default to
+    the current user.
+    """
     userId: ID
+    """
+    Only get orders for the given product ID.
+    """
     productId: ID
 }
 
 input PaymentAttemptsInput {
+    """
+    Only get payment attempts for the given user ID. Requires super user status,
+    or the user ID to match the user ID of the payment attempt. Omit to default to
+    the current user.
+    """
     userId: ID
+    """
+    Only get payment atttempts for the given order ID.
+    """
     orderId: ID
+    """
+    Only get payment attempts for the given product ID.
+    """
     productId: ID
 }
 
@@ -157,6 +176,14 @@ type Mutation {
 
 type Query {
     products: ProductResponse!
+    """
+    Get orders, filtered by the given input. Unless the user is a super user, only
+    orders for the current user will be returned.
+    """
     orders(data: OrdersInput): OrdersResponse!
+    """
+    Get payment attempts, filtered by the given input. Unless the user is a super user, only
+    payment attempts for the current user will be returned.
+    """
     paymentAttempts(data: PaymentAttemptsInput): PaymentAttemptsResponse!
 }

--- a/src/graphql/products/schema.mappers.ts
+++ b/src/graphql/products/schema.mappers.ts
@@ -2,4 +2,5 @@ export type {
 	OrderType as OrderMapper,
 	ProductType as ProductMapper,
 	MerchantType as MerchantMapper,
+	PaymentAttemptType as PaymentAttemptMapper,
 } from "~/domain/products.js";

--- a/src/graphql/test-clients/mock-apollo-server.ts
+++ b/src/graphql/test-clients/mock-apollo-server.ts
@@ -125,11 +125,4 @@ export const createMockApolloServer = (logger?: Partial<FastifyBaseLogger>) => {
 	};
 };
 
-type CreateMockContextData =
-	| { user?: (Partial<User> & { id: string }) | null }
-	| DeprectatedCreateMockContextData;
-
-type DeprectatedCreateMockContextData = Partial<{
-	userId: string;
-	authenticated: boolean;
-}>;
+type CreateMockContextData = { user?: (Partial<User> & { id: string }) | null };

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -305,7 +305,7 @@ type IProductService = {
 			} | null,
 		): ResultAsync<
 			{ paymentAttempts: PaymentAttemptType[]; total: number },
-			InternalServerError | PermissionDeniedError
+			InternalServerError | PermissionDeniedError | UnauthorizedError
 		>;
 	};
 	orders: {
@@ -318,7 +318,7 @@ type IProductService = {
 			params?: { userId?: string | null; productId?: string | null } | null,
 		): ResultAsync<
 			{ orders: OrderType[]; total: number },
-			InternalServerError | PermissionDeniedError
+			InternalServerError | PermissionDeniedError | UnauthorizedError
 		>;
 		get(
 			ctx: Context,

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -35,7 +35,7 @@ import type { Role } from "~/domain/organizations.js";
 import type {
 	MerchantType,
 	OrderType,
-	PaymentAttempt,
+	PaymentAttemptType,
 	ProductType,
 } from "~/domain/products.js";
 import type { StudyProgram, User } from "~/domain/users.js";
@@ -283,7 +283,7 @@ type IProductService = {
 		): ResultAsync<
 			{
 				redirectUrl: string;
-				paymentAttempt: PaymentAttempt;
+				paymentAttempt: PaymentAttemptType;
 				order: OrderType;
 				pollingJob: Job<
 					PaymentProcessingDataType,
@@ -296,12 +296,40 @@ type IProductService = {
 			| InvalidArgumentError
 			| InternalServerError
 		>;
+		findMany(
+			ctx: Context,
+			params?: {
+				userId?: string | null;
+				productId?: string | null;
+				orderId?: string | null;
+			} | null,
+		): ResultAsync<
+			{ paymentAttempts: PaymentAttemptType[]; total: number },
+			InternalServerError | PermissionDeniedError
+		>;
 	};
 	orders: {
 		create(
 			ctx: Context,
 			data: Pick<OrderType, "productId">,
 		): ResultAsync<{ order: OrderType }, UnauthorizedError | NotFoundError>;
+		findMany(
+			ctx: Context,
+			params?: { userId?: string | null; productId?: string | null } | null,
+		): ResultAsync<
+			{ orders: OrderType[]; total: number },
+			InternalServerError | PermissionDeniedError
+		>;
+		get(
+			ctx: Context,
+			params: { id: string },
+		): ResultAsync<
+			{ order: OrderType },
+			| NotFoundError
+			| UnauthorizedError
+			| PermissionDeniedError
+			| InternalServerError
+		>;
 	};
 	products: {
 		findMany(
@@ -310,6 +338,10 @@ type IProductService = {
 			{ products: ProductType[]; total: number },
 			InternalServerError
 		>;
+		get(
+			ctx: Context,
+			params: { id: string },
+		): ResultAsync<{ product: ProductType }, NotFoundError>;
 	};
 	merchants: {
 		create(

--- a/src/repositories/products/__tests__/integration/order.test.ts
+++ b/src/repositories/products/__tests__/integration/order.test.ts
@@ -46,5 +46,135 @@ describe("ProductRepository", () => {
 				}
 			});
 		});
+
+		describe("#findManyOrders", () => {
+			it("returns orders for a user", async () => {
+				/**
+				 * Act
+				 *
+				 * Create an order
+				 */
+				const { order, user, productRepository } = await makeDependencies();
+
+				/**
+				 * Act
+				 *
+				 * Find the order
+				 */
+				const actual = await productRepository.findManyOrders({
+					userId: user.id,
+				});
+				if (!actual.ok) throw actual.error;
+
+				expect(actual.data.orders).toHaveLength(1);
+				expect(actual.data.orders).toEqual([order]);
+			});
+
+			it("returns orders for a product", async () => {
+				/**
+				 * Act
+				 *
+				 * Create an order
+				 */
+				const { order, product, productRepository } = await makeDependencies();
+
+				/**
+				 * Act
+				 *
+				 * Find the order
+				 */
+				const actual = await productRepository.findManyOrders({
+					productId: product.id,
+				});
+				if (!actual.ok) throw actual.error;
+
+				expect(actual.data.orders).toHaveLength(1);
+				expect(actual.data.orders).toEqual([order]);
+			});
+
+			it("returns orders for a product and user", async () => {
+				/**
+				 * Act
+				 *
+				 * Create an order
+				 */
+				const { order, product, user, productRepository } =
+					await makeDependencies();
+				const { user: otherUser, product: otherProduct } =
+					await makeDependencies();
+
+				/**
+				 * Create an order for a different user
+				 */
+				await productRepository.createOrder({
+					userId: otherUser.id,
+					product,
+				});
+
+				/**
+				 * Create an order for a different product, same user.
+				 */
+				await productRepository.createOrder({
+					userId: user.id,
+					product: otherProduct,
+				});
+
+				/**
+				 * Act
+				 *
+				 * Find the order
+				 */
+				const actual = await productRepository.findManyOrders({
+					productId: product.id,
+					userId: user.id,
+				});
+				if (!actual.ok) throw actual.error;
+
+				expect(actual.data.orders).toHaveLength(1);
+				expect(actual.data.orders).toEqual([order]);
+			});
+
+			it("returns all orders", async () => {
+				/**
+				 * Act
+				 *
+				 * Create an order
+				 */
+				const { order, product, user, productRepository } =
+					await makeDependencies();
+				const { user: otherUser, product: otherProduct } =
+					await makeDependencies();
+
+				/**
+				 * Create an order for a different user
+				 */
+				const { order: differentUserOrder } =
+					await productRepository.createOrder({
+						userId: otherUser.id,
+						product,
+					});
+
+				/**
+				 * Create an order for a different product, same user.
+				 */
+				const { order: differentProductOrder } =
+					await productRepository.createOrder({
+						userId: user.id,
+						product: otherProduct,
+					});
+
+				/**
+				 * Act
+				 *
+				 * Find the order
+				 */
+				const actual = await productRepository.findManyOrders();
+				if (!actual.ok) throw actual.error;
+
+				expect(actual.data.orders).toContainEqual(order);
+				expect(actual.data.orders).toContainEqual(differentProductOrder);
+				expect(actual.data.orders).toContainEqual(differentUserOrder);
+			});
+		});
 	});
 });

--- a/src/repositories/products/repository.ts
+++ b/src/repositories/products/repository.ts
@@ -362,6 +362,9 @@ export class ProductRepository {
 		return { product: created };
 	}
 
+	/**
+	 * findManyOrders returns orders for a user, product, or a combination of the two.
+	 */
 	async findManyOrders(params?: {
 		userId?: string;
 		productId?: string;
@@ -390,6 +393,10 @@ export class ProductRepository {
 			},
 		};
 	}
+
+	/**
+	 * findManyPaymentAttempts returns payment attempts for a user, order, or product, or a combination of the three
+	 */
 	async findManyPaymentAttempts(params?: {
 		userId?: string;
 		orderId?: string;

--- a/src/repositories/products/repository.ts
+++ b/src/repositories/products/repository.ts
@@ -9,8 +9,8 @@ import {
 	type MerchantType,
 	Order,
 	type OrderType,
-	type PaymentAttemptType,
 	PaymentAttempt,
+	type PaymentAttemptType,
 	type ProductType,
 } from "~/domain/products.js";
 import { prismaKnownErrorCodes } from "~/lib/prisma.js";

--- a/src/repositories/products/repository.ts
+++ b/src/repositories/products/repository.ts
@@ -9,8 +9,8 @@ import {
 	type MerchantType,
 	Order,
 	type OrderType,
-	type PaymentAttempt,
-	PaymentAttemptFromDSO,
+	type PaymentAttemptType,
+	PaymentAttempt,
 	type ProductType,
 } from "~/domain/products.js";
 import { prismaKnownErrorCodes } from "~/lib/prisma.js";
@@ -150,7 +150,7 @@ export class ProductRepository {
 			version: number;
 		};
 		reference: string;
-	}): Promise<{ paymentAttempt: PaymentAttempt; order: OrderType }> {
+	}): Promise<{ paymentAttempt: PaymentAttemptType; order: OrderType }> {
 		const { reference, order } = paymentAttempt;
 		const paymentAttemptPromise = this.db.paymentAttempt.create({
 			data: {
@@ -184,7 +184,7 @@ export class ProductRepository {
 			]);
 
 			return {
-				paymentAttempt: PaymentAttemptFromDSO(paymentAttemptResult),
+				paymentAttempt: PaymentAttempt.fromDSO(paymentAttemptResult),
 				order: orderResult,
 			};
 		} catch (err) {
@@ -249,7 +249,7 @@ export class ProductRepository {
 	async getPaymentAttempt(
 		by: { id: string } | { reference: string },
 	): ResultAsync<
-		{ paymentAttempt: PaymentAttempt | null },
+		{ paymentAttempt: PaymentAttemptType | null },
 		InternalServerError
 	> {
 		try {
@@ -260,7 +260,7 @@ export class ProductRepository {
 				return { data: { paymentAttempt: null }, ok: true };
 			}
 			return {
-				data: { paymentAttempt: PaymentAttemptFromDSO(attempt) },
+				data: { paymentAttempt: PaymentAttempt.fromDSO(attempt) },
 				ok: true,
 			};
 		} catch (err) {
@@ -278,9 +278,9 @@ export class ProductRepository {
 	 * updatePaymentAttempt updates a payment attempt.
 	 */
 	async updatePaymentAttempt(
-		paymentAttempt: Pick<PaymentAttempt, "state" | "id" | "version">,
+		paymentAttempt: Pick<PaymentAttemptType, "state" | "id" | "version">,
 		order: Pick<OrderType, "id" | "version" | "paymentStatus">,
-	): Promise<{ paymentAttempt: PaymentAttempt; order: OrderType }> {
+	): Promise<{ paymentAttempt: PaymentAttemptType; order: OrderType }> {
 		try {
 			const paymentAttemptPromise = this.db.paymentAttempt.update({
 				where: {
@@ -313,7 +313,7 @@ export class ProductRepository {
 			]);
 
 			return {
-				paymentAttempt: PaymentAttemptFromDSO(updatedPaymentAttempt),
+				paymentAttempt: PaymentAttempt.fromDSO(updatedPaymentAttempt),
 				order: updatedOrder,
 			};
 		} catch (err) {
@@ -360,5 +360,76 @@ export class ProductRepository {
 			data: product,
 		});
 		return { product: created };
+	}
+
+	async findManyOrders(params?: {
+		userId?: string;
+		productId?: string;
+	}): ResultAsync<{ orders: OrderType[]; total: number }, InternalServerError> {
+		const { userId, productId } = params ?? {};
+		const [count, orders] = await this.db.$transaction([
+			this.db.order.count({
+				where: {
+					userId,
+					productId,
+				},
+			}),
+			this.db.order.findMany({
+				where: {
+					userId,
+					productId,
+				},
+			}),
+		]);
+
+		return {
+			ok: true,
+			data: {
+				orders: orders,
+				total: count,
+			},
+		};
+	}
+	async findManyPaymentAttempts(params?: {
+		userId?: string;
+		orderId?: string;
+		productId?: string;
+	}): ResultAsync<
+		{ paymentAttempts: PaymentAttemptType[]; total: number },
+		InternalServerError
+	> {
+		const { userId, orderId, productId } = params ?? {};
+		const [count, paymentAttemptsFromDSO] = await this.db.$transaction([
+			this.db.paymentAttempt.count({
+				where: {
+					order: {
+						id: orderId,
+						userId: userId,
+						productId: productId,
+					},
+				},
+			}),
+			this.db.paymentAttempt.findMany({
+				where: {
+					order: {
+						id: orderId,
+						userId: userId,
+						productId: productId,
+					},
+				},
+			}),
+		]);
+		const paymentAttempts: PaymentAttemptType[] = [];
+		for (const paymentAttempt of paymentAttemptsFromDSO) {
+			paymentAttempts.push(PaymentAttempt.fromDSO(paymentAttempt));
+		}
+
+		return {
+			ok: true,
+			data: {
+				paymentAttempts: paymentAttempts,
+				total: count,
+			},
+		};
 	}
 }

--- a/src/services/products/__tests__/unit/order.test.ts
+++ b/src/services/products/__tests__/unit/order.test.ts
@@ -1,5 +1,6 @@
+import { faker } from "@faker-js/faker";
 import { mock } from "jest-mock-extended";
-import { UnauthorizedError } from "~/domain/errors.js";
+import { PermissionDeniedError, UnauthorizedError } from "~/domain/errors.js";
 import type { OrderType, ProductType } from "~/domain/products.js";
 import type { User } from "~/domain/users.js";
 import { makeMockContext } from "~/lib/context.js";
@@ -38,6 +39,87 @@ describe("OrderService", () => {
 
 			expect(result.ok).toBe(true);
 			expect(productRepository.createOrder).toHaveBeenCalled();
+		});
+	});
+
+	describe("#findMany", () => {
+		it("should return all orders as a super user", async () => {
+			const ctx = makeMockContext(mock<User>({ isSuperUser: true }));
+
+			await productService.orders.findMany(ctx);
+
+			expect(productRepository.findManyOrders).toHaveBeenCalledWith(undefined);
+		});
+
+		it("should return all orders for a user as a super user", async () => {
+			const ctx = makeMockContext(mock<User>({ isSuperUser: true }));
+
+			const userId = faker.string.uuid();
+			await productService.orders.findMany(ctx, { userId });
+
+			expect(productRepository.findManyOrders).toHaveBeenCalledWith({ userId });
+		});
+
+		it("should return all orders for a product as a super user", async () => {
+			const ctx = makeMockContext(mock<User>({ isSuperUser: true }));
+
+			const productId = faker.string.uuid();
+			await productService.orders.findMany(ctx, { productId });
+
+			expect(productRepository.findManyOrders).toHaveBeenCalledWith({
+				productId,
+			});
+		});
+
+		it("should only return your own orders for a product as a regular user", async () => {
+			const user = mock<User>({ id: faker.string.uuid(), isSuperUser: false });
+			const ctx = makeMockContext(user);
+
+			const productId = faker.string.uuid();
+			await productService.orders.findMany(ctx, { productId });
+
+			expect(productRepository.findManyOrders).toHaveBeenCalledWith({
+				productId,
+				userId: user.id,
+			});
+		});
+
+		it("should only return your own orders as a regular user", async () => {
+			const user = mock<User>({ id: faker.string.uuid(), isSuperUser: false });
+			const ctx = makeMockContext(user);
+
+			await productService.orders.findMany(ctx);
+
+			expect(productRepository.findManyOrders).toHaveBeenCalledWith({
+				userId: user.id,
+			});
+		});
+
+		it("should return PermissionDeniedError if you try to fetch orders for a different user as a regular user", async () => {
+			const user = mock<User>({ id: faker.string.uuid(), isSuperUser: false });
+			const ctx = makeMockContext(user);
+
+			const result = await productService.orders.findMany(ctx, {
+				userId: faker.string.uuid(),
+			});
+
+			expect(result).toEqual({
+				ok: false,
+				error: expect.any(PermissionDeniedError),
+			});
+		});
+
+		it("should return UnauthorizedError if not logged in", async () => {
+			const ctx = makeMockContext(null);
+
+			const result = await productService.orders.findMany(ctx, {
+				userId: faker.string.uuid(),
+			});
+
+			expect(result).toEqual({
+				ok: false,
+				error: expect.any(UnauthorizedError),
+			});
 		});
 	});
 });

--- a/src/services/products/__tests__/unit/payment-attempt.test.ts
+++ b/src/services/products/__tests__/unit/payment-attempt.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import type { EPaymentErrorResponse } from "@vippsmobilepay/sdk";
 import { mock } from "jest-mock-extended";
+import { PermissionDeniedError, UnauthorizedError } from "~/domain/errors.js";
 import type {
 	OrderType,
 	PaymentAttemptType,
@@ -345,6 +346,89 @@ describe("ProductService", () => {
 			});
 
 			expect(result.ok).toBe(true);
+		});
+	});
+
+	describe("#findMany", () => {
+		it("should return all payment attempts as a super user", async () => {
+			const ctx = makeMockContext(mock<User>({ isSuperUser: true }));
+			productRepository.findManyPaymentAttempts.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					total: 1,
+					paymentAttempts: [mock<PaymentAttemptType>()],
+				},
+			});
+
+			const result = await productService.payments.findMany(ctx);
+			if (!result.ok) throw result.error;
+
+			expect(productRepository.findManyPaymentAttempts).toHaveBeenCalledWith(
+				undefined,
+			);
+		});
+
+		it("should return UnauthorizedError if not logged in", async () => {
+			const ctx = makeMockContext(null);
+			productRepository.findManyPaymentAttempts.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					total: 1,
+					paymentAttempts: [mock<PaymentAttemptType>()],
+				},
+			});
+
+			const result = await productService.payments.findMany(ctx);
+			expect(result).toEqual({
+				ok: false,
+				error: expect.any(UnauthorizedError),
+			});
+		});
+
+		it("should return all your own payment attempts as a regular user", async () => {
+			const user = mock<User>({
+				id: faker.string.uuid(),
+				isSuperUser: false,
+			});
+			const ctx = makeMockContext(user);
+			productRepository.findManyPaymentAttempts.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					total: 1,
+					paymentAttempts: [mock<PaymentAttemptType>()],
+				},
+			});
+
+			const result = await productService.payments.findMany(ctx);
+			if (!result.ok) throw result.error;
+
+			expect(productRepository.findManyPaymentAttempts).toHaveBeenCalledWith({
+				userId: user.id,
+			});
+		});
+
+		it("should return PermissionDeniedError if you try to fetch other users' payment attempts as a regular user", async () => {
+			const user = mock<User>({
+				id: faker.string.uuid(),
+				isSuperUser: false,
+			});
+			const ctx = makeMockContext(user);
+			productRepository.findManyPaymentAttempts.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					total: 1,
+					paymentAttempts: [mock<PaymentAttemptType>()],
+				},
+			});
+
+			const result = await productService.payments.findMany(ctx, {
+				userId: faker.string.uuid(),
+			});
+
+			expect(result).toEqual({
+				ok: false,
+				error: expect.any(PermissionDeniedError),
+			});
 		});
 	});
 });

--- a/src/services/products/__tests__/unit/payment-attempt.test.ts
+++ b/src/services/products/__tests__/unit/payment-attempt.test.ts
@@ -3,7 +3,7 @@ import type { EPaymentErrorResponse } from "@vippsmobilepay/sdk";
 import { mock } from "jest-mock-extended";
 import type {
 	OrderType,
-	PaymentAttempt,
+	PaymentAttemptType,
 	ProductType,
 } from "~/domain/products.js";
 import type { User } from "~/domain/users.js";
@@ -320,7 +320,7 @@ describe("ProductService", () => {
 			productRepository.getPaymentAttempt.mockResolvedValueOnce({
 				ok: true,
 				data: {
-					paymentAttempt: mock<PaymentAttempt>({}),
+					paymentAttempt: mock<PaymentAttemptType>({}),
 				},
 			});
 
@@ -336,7 +336,7 @@ describe("ProductService", () => {
 			productRepository.getPaymentAttempt.mockResolvedValueOnce({
 				ok: true,
 				data: {
-					paymentAttempt: mock<PaymentAttempt>({}),
+					paymentAttempt: mock<PaymentAttemptType>({}),
 				},
 			});
 

--- a/src/services/products/__tests__/unit/products.test.ts
+++ b/src/services/products/__tests__/unit/products.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { mock } from "jest-mock-extended";
-import { UnauthorizedError } from "~/domain/errors.js";
+import { NotFoundError, UnauthorizedError } from "~/domain/errors.js";
 import type { ProductType } from "~/domain/products.js";
 import type { User } from "~/domain/users.js";
 import { makeMockContext } from "~/lib/context.js";
@@ -59,6 +59,39 @@ describe("ProductService", () => {
 			const result = await productService.products.findMany(ctx);
 
 			expect(result.ok).toBe(true);
+		});
+	});
+
+	describe("#get", () => {
+		it("should return a product", async () => {
+			const ctx = makeMockContext(mock<User>({ isSuperUser: false }));
+
+			productRepository.getProduct.mockResolvedValueOnce({
+				product: mock<ProductType>({}),
+			});
+
+			const result = await productService.products.get(ctx, {
+				id: faker.string.uuid(),
+			});
+
+			expect(result.ok).toBe(true);
+		});
+
+		it("should return NotFound if it doesn't exist", async () => {
+			const ctx = makeMockContext(mock<User>({ isSuperUser: false }));
+
+			productRepository.getProduct.mockResolvedValueOnce({
+				product: null,
+			});
+
+			const result = await productService.products.get(ctx, {
+				id: faker.string.uuid(),
+			});
+
+			expect(result).toEqual({
+				ok: false,
+				error: expect.any(NotFoundError),
+			});
 		});
 	});
 });

--- a/src/services/products/orders.ts
+++ b/src/services/products/orders.ts
@@ -1,7 +1,7 @@
 import {
 	type InternalServerError,
 	NotFoundError,
-	type PermissionDeniedError,
+	PermissionDeniedError,
 	UnauthorizedError,
 } from "~/domain/errors.js";
 import type { OrderType } from "~/domain/products.js";
@@ -93,6 +93,25 @@ function buildOrders({ productRepository }: BuildProductsDependencies) {
 			}
 
 			return { ok: true, data: { order } };
+		},
+
+		async findMany(
+			ctx: Context,
+			params?: { userId?: string; productId?: string },
+		): ResultAsync<
+			{ orders: OrderType[]; total: number },
+			InternalServerError | PermissionDeniedError
+		> {
+			if (!ctx.user?.isSuperUser) {
+				return {
+					ok: false,
+					error: new PermissionDeniedError(
+						"You must be a super user to get orders",
+					),
+				};
+			}
+
+			return await productRepository.findManyOrders(params);
 		},
 	} as const;
 }

--- a/src/services/products/products.ts
+++ b/src/services/products/products.ts
@@ -2,6 +2,7 @@ import {
 	InternalServerError,
 	type InvalidArgumentError,
 	UnauthorizedError,
+	NotFoundError,
 } from "~/domain/errors.js";
 import { Product, type ProductType } from "~/domain/products.js";
 import type { ResultAsync } from "~/lib/result.js";
@@ -60,6 +61,21 @@ function buildProducts({ productRepository }: BuildProductsDependencies) {
 					error: new InternalServerError("Failed to get products"),
 				};
 			}
+		},
+
+		async get(
+			_ctx: Context,
+			params: { id: string },
+		): ResultAsync<{ product: ProductType }, NotFoundError> {
+			const { product } = await productRepository.getProduct(params.id);
+			if (!product) {
+				return {
+					ok: false,
+					error: new NotFoundError("Product not found"),
+				};
+			}
+
+			return { ok: true, data: { product } };
 		},
 	} as const;
 }

--- a/src/services/products/products.ts
+++ b/src/services/products/products.ts
@@ -1,8 +1,8 @@
 import {
 	InternalServerError,
 	type InvalidArgumentError,
-	UnauthorizedError,
 	NotFoundError,
+	UnauthorizedError,
 } from "~/domain/errors.js";
 import { Product, type ProductType } from "~/domain/products.js";
 import type { ResultAsync } from "~/lib/result.js";

--- a/src/services/products/service.ts
+++ b/src/services/products/service.ts
@@ -3,7 +3,7 @@ import type { InternalServerError } from "~/domain/errors.js";
 import type {
 	MerchantType,
 	OrderType,
-	PaymentAttempt,
+	PaymentAttemptType,
 	ProductType,
 } from "~/domain/products.js";
 import type { ResultAsync } from "~/lib/result.js";
@@ -18,6 +18,10 @@ interface ProductRepository {
 	getOrder(
 		id: string,
 	): ResultAsync<{ order: OrderType | null }, InternalServerError>;
+	findManyOrders(params?: { userId?: string; productId?: string }): ResultAsync<
+		{ orders: OrderType[]; total: number },
+		InternalServerError
+	>;
 	createOrder(order: {
 		userId: string;
 		product: {
@@ -31,17 +35,25 @@ interface ProductRepository {
 			version: number;
 		};
 		reference: string;
-	}): Promise<{ paymentAttempt: PaymentAttempt; order: OrderType }>;
+	}): Promise<{ paymentAttempt: PaymentAttemptType; order: OrderType }>;
 	getPaymentAttempt(
 		by: { id: string } | { reference: string },
 	): ResultAsync<
-		{ paymentAttempt: PaymentAttempt | null },
+		{ paymentAttempt: PaymentAttemptType | null },
+		InternalServerError
+	>;
+	findManyPaymentAttempts(params?: {
+		userId?: string;
+		orderId?: string;
+		productId?: string;
+	}): ResultAsync<
+		{ paymentAttempts: PaymentAttemptType[]; total: number },
 		InternalServerError
 	>;
 	updatePaymentAttempt(
-		paymentAttempt: Pick<PaymentAttempt, "id" | "version" | "state">,
+		paymentAttempt: Pick<PaymentAttemptType, "id" | "version" | "state">,
 		order: Pick<OrderType, "id" | "version" | "paymentStatus">,
-	): Promise<{ paymentAttempt: PaymentAttempt; order: OrderType }>;
+	): Promise<{ paymentAttempt: PaymentAttemptType; order: OrderType }>;
 	getProducts(): Promise<{ products: ProductType[]; total: number }>;
 	createProduct(product: {
 		name: string;

--- a/src/services/products/worker.ts
+++ b/src/services/products/worker.ts
@@ -1,11 +1,11 @@
 import { type Processor, UnrecoverableError } from "bullmq";
 import type { Logger } from "pino";
 import type { InternalServerError, NotFoundError } from "~/domain/errors.js";
-import type { PaymentAttempt } from "~/domain/products.js";
 import type { Queue } from "~/lib/bullmq/queue.js";
 import type { Worker } from "~/lib/bullmq/worker.js";
 import type { Result, ResultAsync } from "~/lib/result.js";
 import type { Context } from "../../lib/context.js";
+import type { PaymentAttemptType } from "~/domain/products.js";
 
 type PaymentProcessingDataType = { reference: string };
 type PaymentProcessingResultType = Result<
@@ -32,14 +32,14 @@ type ProductService = {
 			ctx: Context,
 			params: { reference: string },
 		): ResultAsync<
-			{ paymentAttempt: PaymentAttempt | null },
+			{ paymentAttempt: PaymentAttemptType | null },
 			InternalServerError
 		>;
 		updatePaymentAttemptState(
 			ctx: Context,
-			paymentAttempt: PaymentAttempt,
+			paymentAttempt: PaymentAttemptType,
 		): ResultAsync<
-			{ paymentAttempt: PaymentAttempt },
+			{ paymentAttempt: PaymentAttemptType },
 			NotFoundError | InternalServerError
 		>;
 	};

--- a/src/services/products/worker.ts
+++ b/src/services/products/worker.ts
@@ -1,11 +1,11 @@
 import { type Processor, UnrecoverableError } from "bullmq";
 import type { Logger } from "pino";
 import type { InternalServerError, NotFoundError } from "~/domain/errors.js";
+import type { PaymentAttemptType } from "~/domain/products.js";
 import type { Queue } from "~/lib/bullmq/queue.js";
 import type { Worker } from "~/lib/bullmq/worker.js";
 import type { Result, ResultAsync } from "~/lib/result.js";
 import type { Context } from "../../lib/context.js";
-import type { PaymentAttemptType } from "~/domain/products.js";
 
 type PaymentProcessingDataType = { reference: string };
 type PaymentProcessingResultType = Result<


### PR DESCRIPTION
### Changes
- Add methods to fetch all orders and payment attempts for a user/product/order, depending on the filters you pass in, and if you're a super user or not.