### PR TITLE
:sparkles: feat(organizations): resolve related listings and events

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -657,6 +657,7 @@ type OrdersResponse {
 
 type Organization {
   description: String!
+  events: [Event!]!
 
   """
   The features that are enabled for the organization.
@@ -664,10 +665,19 @@ type Organization {
   """
   featurePermissions: [FeaturePermission!]!
   id: ID!
+  listings: [Listing!]!
 
   """The members of the organization"""
   members: [Member!]!
   name: String!
+}
+
+input OrganizationInput {
+  id: ID!
+}
+
+type OrganizationReseponse {
+  organization: Organization!
 }
 
 type OrganizationsResponse {
@@ -856,8 +866,11 @@ type Query {
   """
   orders(data: OrdersInput): OrdersResponse!
 
+  """Get an organization by its ID"""
+  organization(data: OrganizationInput!): OrganizationReseponse!
+
   """Get all organizations"""
-  organizations: OrganizationsResponse
+  organizations: OrganizationsResponse!
 
   """
   Get payment attempts, filtered by the given input. Unless the user is a super user, only

--- a/src/graphql/organizations/resolvers/Organization.ts
+++ b/src/graphql/organizations/resolvers/Organization.ts
@@ -10,4 +10,12 @@ export const Organization: OrganizationResolvers = {
 		/* Organization.featurePermissions resolver is required because Organization.featurePermissions and OrganizationMapper.featurePermissions are not compatible */
 		return featurePermissions;
 	},
+	events: async ({ id }, _args, ctx) => {
+		const events = await ctx.events.findMany({ organizationId: id });
+		return events;
+	},
+	listings: async ({ id }, _args, ctx) => {
+		const listings = await ctx.listings.findMany({ organizationId: id });
+		return listings;
+	},
 };

--- a/src/graphql/organizations/resolvers/OrganizationReseponse.ts
+++ b/src/graphql/organizations/resolvers/OrganizationReseponse.ts
@@ -1,0 +1,4 @@
+import type { OrganizationReseponseResolvers } from "./../../types.generated.js";
+export const OrganizationReseponse: OrganizationReseponseResolvers = {
+	/* Implement OrganizationReseponse resolver logic here */
+};

--- a/src/graphql/organizations/resolvers/Query/organization.ts
+++ b/src/graphql/organizations/resolvers/Query/organization.ts
@@ -1,0 +1,9 @@
+import type { QueryResolvers } from "./../../../types.generated.js";
+export const organization: NonNullable<QueryResolvers["organization"]> = async (
+	_parent,
+	{ data },
+	ctx,
+) => {
+	const organization = await ctx.organizations.get(data.id);
+	return { organization };
+};

--- a/src/graphql/organizations/resolvers/Query/organization.unit.test.ts
+++ b/src/graphql/organizations/resolvers/Query/organization.unit.test.ts
@@ -1,0 +1,56 @@
+import { faker } from "@faker-js/faker";
+import type { Organization } from "@prisma/client";
+import { mock } from "jest-mock-extended";
+import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "~/graphql/test-clients/unit/gql.js";
+
+describe("Organization Queries", () => {
+	describe("organization", () => {
+		it("{ organization { events, listings } } should resolve lisitngs and events for the organization", async () => {
+			const { client, eventService, listingService, organizationService } =
+				createMockApolloServer();
+
+			/**
+			 * Arrange
+			 *
+			 * Set up mocks for the organization service
+			 */
+			const organizationId = faker.string.uuid();
+			organizationService.get.mockResolvedValue(
+				mock<Organization>({ id: organizationId }),
+			);
+
+			/**
+			 * Act
+			 */
+			const actual = await client.query({
+				query: graphql(`
+                    query organization($data: OrganizationInput!) {
+                        organization(data: $data) {
+                            organization {
+                                events {
+                                    id
+                                }
+                                listings {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                `),
+				variables: {
+					data: {
+						id: organizationId,
+					},
+				},
+			});
+
+			/**
+			 * Assert
+			 */
+			expect(actual).toBeDefined();
+			expect(listingService.findMany).toHaveBeenCalledWith({ organizationId });
+			expect(eventService.findMany).toHaveBeenCalledWith({ organizationId });
+		});
+	});
+});

--- a/src/graphql/organizations/schema.graphql
+++ b/src/graphql/organizations/schema.graphql
@@ -11,6 +11,8 @@ type Organization {
   Changing these fields requires super user permissions.
   """
   featurePermissions: [FeaturePermission!]!
+  events: [Event!]!
+  listings: [Listing!]!
 }
 
 type Member {
@@ -122,24 +124,40 @@ type OrganizationsResponse {
   organizations: [Organization!]!
 }
 
+type OrganizationReseponse {
+  organization: Organization!
+}
+
+input OrganizationInput {
+  id: ID!
+}
+
 type Query {
+  """
+  Get an organization by its ID
+  """
+  organization(data: OrganizationInput!): OrganizationReseponse!
   """
   Get all organizations
   """
-  organizations: OrganizationsResponse
+  organizations: OrganizationsResponse!
 }
 
 type Mutation {
   """
   Create a new organization, and add the current user as an admin of the organization.
   """
-  createOrganization(data: CreateOrganizationInput!): CreateOrganizationResponse!
+  createOrganization(
+    data: CreateOrganizationInput!
+  ): CreateOrganizationResponse!
 
   """
   Update an organization with the given name and description.
   Passing null or omitting a value will leave the value unchanged.
   """
-  updateOrganization(data: UpdateOrganizationInput!): UpdateOrganizationResponse!
+  updateOrganization(
+    data: UpdateOrganizationInput!
+  ): UpdateOrganizationResponse!
 
   """
   Add a member to the organization

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -221,7 +221,10 @@ interface IEventService {
 		| NotFoundError
 	>;
 	get(id: string): Promise<EventType>;
-	findMany(data?: { onlyFutureEvents?: boolean | null }): Promise<EventType[]>;
+	findMany(data?: {
+		onlyFutureEvents?: boolean | null;
+		organizationId?: string | null;
+	}): Promise<EventType[]>;
 	signUp(
 		ctx: Context,
 		params: {
@@ -275,7 +278,7 @@ interface IEventService {
 
 interface IListingService {
 	get(id: string): Promise<Listing>;
-	findMany(): Promise<Listing[]>;
+	findMany(params?: { organizationId?: string | null }): Promise<Listing[]>;
 	create(
 		userId: string,
 		data: {

--- a/src/repositories/events/repository.ts
+++ b/src/repositories/events/repository.ts
@@ -455,11 +455,14 @@ export class EventRepository {
 	 * @param data.endAtGte - Only return events that end after this date
 	 * @returns A list of events
 	 */
-	async findMany(data?: { endAtGte?: Date }): Promise<EventType[]> {
+	async findMany(data?: { endAtGte?: Date; organizationId?: string }): Promise<
+		EventType[]
+	> {
 		if (data) {
-			const { endAtGte } = data;
+			const { endAtGte, organizationId } = data;
 			const events = await this.db.event.findMany({
 				where: {
+					organizationId,
 					endAt: {
 						gte: endAtGte,
 					},

--- a/src/repositories/listings/__tests__/integration/listings.test.ts
+++ b/src/repositories/listings/__tests__/integration/listings.test.ts
@@ -139,6 +139,41 @@ describe("ListingRepository", () => {
 			expect(actual).toContainEqual(listing2);
 			expect(actual).toContainEqual(listing3);
 		});
+		it("retrieves all listings for an organization", async () => {
+			/**
+			 * Arrange
+			 *
+			 * Create 3 listings
+			 */
+			const otherOrganization = await prisma.organization.create({
+				data: {
+					name: faker.string.sample(20),
+				},
+			});
+			const listing1 = await makeListing({ organizationId: organization.id });
+			const listing2 = await makeListing({ organizationId: organization.id });
+			const listing3 = await makeListing({ organizationId: organization.id });
+			const listing4 = await makeListing({
+				organizationId: otherOrganization.id,
+			});
+
+			// Act
+			const actual = await listingRepository.findMany({
+				organizationId: organization.id,
+			});
+
+			/**
+			 * Assert
+			 *
+			 * All three listings should be present in the response
+			 */
+			expect(actual).toBeDefined();
+			expect(actual.length).toBeGreaterThanOrEqual(3);
+			expect(actual).toContainEqual(listing1);
+			expect(actual).toContainEqual(listing2);
+			expect(actual).toContainEqual(listing3);
+			expect(actual).not.toContainEqual(listing4);
+		});
 	});
 });
 

--- a/src/repositories/listings/repository.ts
+++ b/src/repositories/listings/repository.ts
@@ -98,7 +98,14 @@ export class ListingRepository {
 	 * findMany returns all listings
 	 * @returns all listings
 	 */
-	findMany(): Promise<Listing[]> {
+	findMany(params?: { organizationId?: string }): Promise<Listing[]> {
+		if (params?.organizationId) {
+			return this.db.listing.findMany({
+				where: {
+					organizationId: params.organizationId,
+				},
+			});
+		}
 		return this.db.listing.findMany();
 	}
 }

--- a/src/services/events/__tests__/unit/find-many.test.ts
+++ b/src/services/events/__tests__/unit/find-many.test.ts
@@ -1,0 +1,52 @@
+import { faker } from "@faker-js/faker";
+import { jest } from "@jest/globals";
+import type { DeepMockProxy } from "jest-mock-extended";
+import type { EventRepository, EventService } from "../../service.js";
+import { makeDependencies } from "./dependencies.js";
+
+describe("EventService", () => {
+	let eventService: InstanceType<typeof EventService>;
+	let eventRepository: DeepMockProxy<EventRepository>;
+
+	beforeAll(() => {
+		const deps = makeDependencies();
+		eventService = deps.service;
+		eventRepository = deps.eventsRepository;
+		jest.useFakeTimers();
+	});
+
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
+	describe("#findMany", () => {
+		it("should try to fetch events for an organization", async () => {
+			/**
+			 * Arrange
+			 */
+			const organizationId = faker.string.uuid();
+
+			/**
+			 * Act
+			 */
+			await eventService.findMany({ organizationId });
+			expect(eventRepository.findMany).toHaveBeenCalledWith({
+				organizationId,
+			});
+		});
+
+		it("should try to fetch events in the future", async () => {
+			/**
+			 * Arrange
+			 */
+			jest.setSystemTime(new Date(2021, 0, 1));
+			/**
+			 * Act
+			 */
+			await eventService.findMany({ onlyFutureEvents: true });
+			expect(eventRepository.findMany).toHaveBeenCalledWith({
+				endAtGte: new Date(2021, 0, 1),
+			});
+		});
+	});
+});

--- a/src/services/events/service.ts
+++ b/src/services/events/service.ts
@@ -81,7 +81,9 @@ interface EventRepository {
 		eventId: string,
 		gradeYear?: number,
 	): Promise<EventSlot | null>;
-	findMany(data?: { endAtGte?: Date | null }): Promise<EventType[]>;
+	findMany(data?: { endAtGte?: Date | null; organizationId?: string }): Promise<
+		EventType[]
+	>;
 	findManySignUps(data: {
 		eventId: string;
 		status: ParticipationStatus;
@@ -745,17 +747,25 @@ class EventService {
 	 * @params data.onlyFutureEvents - If true, only future events that have an `endAt` in the future will be returned
 	 * @returns All events
 	 */
-	async findMany(data?: { onlyFutureEvents?: boolean }): Promise<EventType[]> {
+	async findMany(data?: {
+		onlyFutureEvents?: boolean;
+		organizationId?: string | null;
+	}): Promise<EventType[]> {
 		if (!data) {
 			return await this.eventRepository.findMany();
 		}
 
-		let endAtGte: Date | undefined;
+		let endAtGte: Date | undefined = undefined;
 		if (data.onlyFutureEvents) {
 			endAtGte = DateTime.now().toJSDate();
 		}
 
-		return await this.eventRepository.findMany({ endAtGte });
+		let organizationId: string | undefined = undefined;
+		if (data.organizationId) {
+			organizationId = data.organizationId;
+		}
+
+		return await this.eventRepository.findMany({ endAtGte, organizationId });
 	}
 
 	/**

--- a/src/services/listings/__tests__/unit/find-many.test.ts
+++ b/src/services/listings/__tests__/unit/find-many.test.ts
@@ -1,0 +1,36 @@
+import { faker } from "@faker-js/faker";
+import { type DeepMockProxy, mockDeep } from "jest-mock-extended";
+import {
+	type ListingRepository,
+	ListingService,
+	type PermissionService,
+} from "../../service.js";
+
+describe("ListingService", () => {
+	let listingService: ListingService;
+	let listingRepository: DeepMockProxy<ListingRepository>;
+	let permissionService: DeepMockProxy<PermissionService>;
+
+	beforeAll(() => {
+		listingRepository = mockDeep<ListingRepository>();
+		permissionService = mockDeep<PermissionService>();
+		listingService = new ListingService(listingRepository, permissionService);
+	});
+
+	describe("#findMany", () => {
+		it("should try to fetch listings for an organization", async () => {
+			/**
+			 * Arrange
+			 */
+			const organizationId = faker.string.uuid();
+
+			/**
+			 * Act
+			 */
+			await listingService.findMany({ organizationId });
+			expect(listingRepository.findMany).toHaveBeenCalledWith({
+				organizationId,
+			});
+		});
+	});
+});

--- a/src/services/listings/service.ts
+++ b/src/services/listings/service.ts
@@ -24,7 +24,7 @@ export interface ListingRepository {
 			applicationUrl: string;
 		}>,
 	): Promise<Listing>;
-	findMany(): Promise<Listing[]>;
+	findMany(params?: { organizationId?: string }): Promise<Listing[]>;
 	delete(id: string): Promise<Listing>;
 }
 
@@ -53,7 +53,12 @@ export class ListingService {
 	/**
 	 * findMany returns all listings
 	 */
-	findMany(): Promise<Listing[]> {
+	findMany(params?: { organizationId?: string | null }): Promise<Listing[]> {
+		if (params?.organizationId) {
+			return this.listingRepository.findMany({
+				organizationId: params.organizationId,
+			});
+		}
 		return this.listingRepository.findMany();
 	}
 


### PR DESCRIPTION
### Changes
- Add listings and events to the organization type, and add resolvers.
- Update findMany methods for events and listings to resolve for a specific organization
- Add tests to cover the changes