### PR TITLE
:sparkles: feat(events): remove sign ups

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -542,6 +542,11 @@ type Mutation {
   removeMember(data: RemoveMemberInput!): RemoveMemberResponse!
 
   """
+  Remove an active sign up for an event, requires that the user is logged in and a member of the organization that is hosting the event
+  """
+  removeSignUp(data: RemoveSignUpInput!): RemoveSignUpResponse!
+
+  """
   Retract an active sign up for an event, requires that the user is logged in
   """
   retractSignUp(data: RetractSignUpInput!): RetractSignUpResponse!
@@ -929,6 +934,16 @@ input RemoveMemberInput {
 
 type RemoveMemberResponse {
   member: Member!
+}
+
+input RemoveSignUpInput {
+  """The id of the sign up to remove"""
+  signUpId: ID!
+}
+
+type RemoveSignUpResponse {
+  """The sign up that was removed"""
+  signUp: SignUp!
 }
 
 input RetractSignUpInput {

--- a/src/graphql/events/resolvers/Event.ts
+++ b/src/graphql/events/resolvers/Event.ts
@@ -1,25 +1,18 @@
-import { AuthenticationError } from "~/domain/errors.js";
 import { Event as DomainEvent } from "~/domain/events/index.js";
-import { assertIsAuthenticated } from "~/graphql/auth.js";
 import type { EventResolvers } from "./../../types.generated.js";
 export const Event: EventResolvers = {
 	/* Implement Event resolver logic here */
 	canSignUp: (parent, _args, ctx) => {
-		try {
-			assertIsAuthenticated(ctx);
-			const canSignUp = ctx.events.canSignUpForEvent(ctx.user.id, parent.id);
-			return canSignUp;
-		} catch (err) {
-			if (err instanceof AuthenticationError) return false;
-			throw err;
-		}
+		const canSignUp = ctx.events.canSignUpForEvent(ctx, {
+			eventId: parent.id,
+		});
+		return canSignUp;
 	},
 
 	signUpAvailability: async (event, _args, ctx) => {
-		const signUpAvailability = await ctx.events.getSignUpAvailability(
-			ctx.user?.id,
-			event.id,
-		);
+		const signUpAvailability = await ctx.events.getSignUpAvailability(ctx, {
+			eventId: event.id,
+		});
 		return signUpAvailability;
 	},
 

--- a/src/graphql/events/resolvers/Mutation/removeSignUp.ts
+++ b/src/graphql/events/resolvers/Mutation/removeSignUp.ts
@@ -1,0 +1,10 @@
+import type { MutationResolvers } from "./../../../types.generated.js";
+export const removeSignUp: NonNullable<MutationResolvers["removeSignUp"]> =
+	async (_parent, { data }, ctx) => {
+		const removeSignUpResult = await ctx.events.removeSignUp(ctx, data);
+		if (!removeSignUpResult.ok) {
+			throw removeSignUpResult.error;
+		}
+		const { signUp } = removeSignUpResult.data;
+		return { signUp };
+	};

--- a/src/graphql/events/resolvers/Mutation/removeSignUp.unit.test.ts
+++ b/src/graphql/events/resolvers/Mutation/removeSignUp.unit.test.ts
@@ -1,0 +1,121 @@
+import { faker } from "@faker-js/faker";
+import type { EventSignUp } from "@prisma/client";
+import { mock } from "jest-mock-extended";
+import { InvalidArgumentError } from "~/domain/errors.js";
+import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "~/graphql/test-clients/unit/gql.js";
+
+describe("Event Mutations", () => {
+	describe("removeSignUp", () => {
+		it("calls events.removeSignUp with the provided data", async () => {
+			const { client, createMockContext, eventService } =
+				createMockApolloServer();
+
+			const signUpId = faker.string.uuid();
+			const userId = faker.string.uuid();
+			eventService.removeSignUp.mockResolvedValue({
+				ok: true,
+				data: {
+					signUp: mock<EventSignUp>({
+						id: signUpId,
+					}),
+				},
+			});
+
+			const { data, errors } = await client.mutate(
+				{
+					mutation: graphql(`
+                    mutation RemoveSignUp($data: RemoveSignUpInput!) {
+                        removeSignUp(data: $data) {
+                            signUp {
+                                id
+                            }
+                        }
+                    }
+                `),
+					variables: {
+						data: {
+							signUpId,
+						},
+					},
+				},
+				{
+					contextValue: createMockContext({
+						user: {
+							id: userId,
+						},
+					}),
+				},
+			);
+
+			expect(eventService.removeSignUp).toHaveBeenCalledWith(
+				expect.objectContaining({
+					user: expect.objectContaining({
+						id: userId,
+					}),
+				}),
+				expect.objectContaining({
+					signUpId: signUpId,
+				}),
+			);
+			expect(data).toEqual({
+				removeSignUp: {
+					signUp: {
+						id: signUpId,
+					},
+				},
+			});
+			expect(errors).toBeUndefined();
+		});
+
+		it("throws if the removal fails", async () => {
+			const { client, createMockContext, eventService } =
+				createMockApolloServer();
+
+			const signUpId = faker.string.uuid();
+			const userId = faker.string.uuid();
+			eventService.removeSignUp.mockResolvedValue({
+				ok: false,
+				error: new InvalidArgumentError(""),
+			});
+
+			const { errors } = await client.mutate(
+				{
+					mutation: graphql(`
+                    mutation RemoveSignUp($data: RemoveSignUpInput!) {
+                        removeSignUp(data: $data) {
+                            signUp {
+                                id
+                            }
+                        }
+                    }
+                `),
+					variables: {
+						data: {
+							signUpId,
+						},
+					},
+				},
+				{
+					contextValue: createMockContext({
+						user: {
+							id: userId,
+						},
+					}),
+				},
+			);
+
+			expect(eventService.removeSignUp).toHaveBeenCalledWith(
+				expect.objectContaining({
+					user: expect.objectContaining({
+						id: userId,
+					}),
+				}),
+				expect.objectContaining({
+					signUpId: signUpId,
+				}),
+			);
+			expect(errors).toBeDefined();
+		});
+	});
+});

--- a/src/graphql/events/resolvers/Mutation/retractSignUp.ts
+++ b/src/graphql/events/resolvers/Mutation/retractSignUp.ts
@@ -1,9 +1,10 @@
-import { assertIsAuthenticated } from "~/graphql/auth.js";
 import type { MutationResolvers } from "./../../../types.generated.js";
 export const retractSignUp: NonNullable<MutationResolvers["retractSignUp"]> =
 	async (_parent, { data }, ctx) => {
-		assertIsAuthenticated(ctx);
-
-		const signUp = await ctx.events.retractSignUp(ctx.user.id, data.eventId);
+		const retractSignUpResult = await ctx.events.retractSignUp(ctx, data);
+		if (!retractSignUpResult.ok) {
+			throw retractSignUpResult.error;
+		}
+		const { signUp } = retractSignUpResult.data;
 		return { signUp };
 	};

--- a/src/graphql/events/resolvers/Query/event.unit.test.ts
+++ b/src/graphql/events/resolvers/Query/event.unit.test.ts
@@ -83,35 +83,12 @@ describe("Event queries", () => {
 
 				expect(errors).toBeUndefined();
 				expect(eventService.canSignUpForEvent).toHaveBeenCalledWith(
-					userId,
-					eventId,
+					expect.anything(),
+					{
+						eventId,
+					},
 				);
 				expect(data?.event.event.canSignUp).toBe(true);
-			});
-
-			it("should return false if the user is not authenticated", async () => {
-				const { client, eventService } = createMockApolloServer();
-				eventService.get.mockResolvedValue(
-					mock<EventType>({ id: faker.string.uuid() }),
-				);
-
-				const { errors, data } = await client.query({
-					query: graphql(`
-            query CanSignUpEvent($data: EventInput!) {
-              event(data: $data) {
-                event {
-                  canSignUp
-                }
-              }
-            }
-          `),
-					variables: {
-						data: { id: faker.string.uuid() },
-					},
-				});
-
-				expect(errors).toBeUndefined();
-				expect(data?.event.event.canSignUp).toBe(false);
 			});
 
 			it("should return false if canSignUpForEvent returns false", async () => {

--- a/src/graphql/events/resolvers/RemoveSignUpResponse.ts
+++ b/src/graphql/events/resolvers/RemoveSignUpResponse.ts
@@ -1,0 +1,4 @@
+import type { RemoveSignUpResponseResolvers } from "./../../types.generated.js";
+export const RemoveSignUpResponse: RemoveSignUpResponseResolvers = {
+	/* Implement RemoveSignUpResponse resolver logic here */
+};

--- a/src/graphql/events/schema.graphql
+++ b/src/graphql/events/schema.graphql
@@ -1,3 +1,49 @@
+type Mutation {
+  """
+  """
+  updateEvent(id: ID!, data: UpdateEventInput!): UpdateEventResponse!
+  """
+  Retract an active sign up for an event, requires that the user is logged in
+  """
+  retractSignUp(data: RetractSignUpInput!): RetractSignUpResponse!
+  """
+  Remove an active sign up for an event, requires that the user is logged in and a member of the organization that is hosting the event
+  """
+  removeSignUp(data: RemoveSignUpInput!): RemoveSignUpResponse!
+  """
+  Sign up for an event, requires that the user is logged in
+  """
+  signUp(data: SignUpInput!): SignUpResponse!
+  """
+  Create an event, requires that the user is logged in, and is a member of the organization that is hosting the event
+  """
+  createEvent(data: CreateEventInput!): CreateEventResponse!
+  """
+  Create a new event category, requires super user status
+  """
+  createEventCategory(
+    data: CreateEventCategoryInput!
+  ): CreateEventCategoryResponse!
+  """
+  Update an event category, requires super user status
+  """
+  updateEventCategory(
+    data: UpdateEventCategoryInput!
+  ): UpdateEventCategoryResponse!
+  """
+  Delete an event category, requires super user status
+  """
+  deleteEventCategory(
+    data: DeleteEventCategoryInput!
+  ): DeleteEventCategoryResponse!
+}
+
+type Query {
+  event(data: EventInput!): EventResponse!
+  events(data: EventsInput): EventsResponse!
+  categories: EventCategoriesResponse!
+}
+
 type Event {
   id: ID!
   """
@@ -478,44 +524,16 @@ type EventCategoriesResponse {
   categories: [EventCategory!]!
 }
 
-type Mutation {
+input RemoveSignUpInput {
   """
+  The id of the sign up to remove
   """
-  updateEvent(id: ID!, data: UpdateEventInput!): UpdateEventResponse!
-  """
-  Retract an active sign up for an event, requires that the user is logged in
-  """
-  retractSignUp(data: RetractSignUpInput!): RetractSignUpResponse!
-  """
-  Sign up for an event, requires that the user is logged in
-  """
-  signUp(data: SignUpInput!): SignUpResponse!
-  """
-  Create an event, requires that the user is logged in, and is a member of the organization that is hosting the event
-  """
-  createEvent(data: CreateEventInput!): CreateEventResponse!
-  """
-  Create a new event category, requires super user status
-  """
-  createEventCategory(
-    data: CreateEventCategoryInput!
-  ): CreateEventCategoryResponse!
-  """
-  Update an event category, requires super user status
-  """
-  updateEventCategory(
-    data: UpdateEventCategoryInput!
-  ): UpdateEventCategoryResponse!
-  """
-  Delete an event category, requires super user status
-  """
-  deleteEventCategory(
-    data: DeleteEventCategoryInput!
-  ): DeleteEventCategoryResponse!
+  signUpId: ID!
 }
 
-type Query {
-  event(data: EventInput!): EventResponse!
-  events(data: EventsInput): EventsResponse!
-  categories: EventCategoriesResponse!
+type RemoveSignUpResponse {
+  """
+  The sign up that was removed
+  """
+  signUp: SignUp!
 }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -361,6 +361,16 @@ interface IEventService {
 		| UnauthorizedError
 		| InvalidArgumentError
 	>;
+	removeSignUp(
+		ctx: Context,
+		params: { signUpId: string },
+	): ResultAsync<
+		{ signUp: EventSignUp },
+		| InternalServerError
+		| InvalidArgumentError
+		| UnauthorizedError
+		| PermissionDeniedError
+	>;
 }
 
 interface IListingService {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -288,11 +288,23 @@ interface IEventService {
 		{ signUp: EventSignUp },
 		InvalidArgumentError | UnauthorizedError | InternalServerError
 	>;
-	retractSignUp(userId: string, eventId: string): Promise<EventSignUp>;
-	canSignUpForEvent(userId: string, eventId: string): Promise<boolean>;
+	retractSignUp(
+		ctx: Context,
+		params: { eventId: string },
+	): ResultAsync<
+		{ signUp: EventSignUp },
+		| NotFoundError
+		| InternalServerError
+		| UnauthorizedError
+		| InvalidArgumentError
+	>;
+	canSignUpForEvent(
+		ctx: Context,
+		params: { eventId: string },
+	): Promise<boolean>;
 	getSignUpAvailability(
-		userId: string | undefined,
-		eventId: string,
+		ctx: Context,
+		params: { eventId: string },
 	): Promise<SignUpAvailability>;
 	createCategory(
 		ctx: UserContext,
@@ -370,6 +382,7 @@ interface IEventService {
 		| InvalidArgumentError
 		| UnauthorizedError
 		| PermissionDeniedError
+		| NotFoundError
 	>;
 }
 

--- a/src/repositories/events/repository.ts
+++ b/src/repositories/events/repository.ts
@@ -1357,6 +1357,37 @@ export class EventRepository {
 			};
 		}
 	}
+
+	public async getSignUpById(params: { id: string }): ResultAsync<
+		{ signUp: EventSignUp },
+		NotFoundError | InternalServerError
+	> {
+		const { id } = params;
+		try {
+			const signUp = await this.db.eventSignUp.findUnique({
+				where: {
+					id,
+				},
+			});
+			if (signUp === null) {
+				return {
+					ok: false,
+					error: new NotFoundError(`Sign up with id: ${id} not found`),
+				};
+			}
+			return {
+				ok: true,
+				data: {
+					signUp,
+				},
+			};
+		} catch (err) {
+			return {
+				ok: false,
+				error: new InternalServerError("Failed to get sign up by ID", err),
+			};
+		}
+	}
 }
 
 interface CreateConfirmedSignUpData {

--- a/src/repositories/events/repository.ts
+++ b/src/repositories/events/repository.ts
@@ -1159,30 +1159,47 @@ export class EventRepository {
 	}
 
 	/**
-	 * getSignUp returns the sign up for the user on the event.
-	 * @throws {NotFoundError} If a sign up with the given ID does not exist
+	 * getActiveSignUp returns the sign up for the user on the event.
 	 * @param userId - The ID of the user to get the sign up for
 	 * @param eventId - The ID of the event to get the sign up for
 	 * @returns the sign up that matches the given user and event IDs
 	 */
-	async getSignUp(userId: string, eventId: string): Promise<EventSignUp> {
-		const signUp = await this.db.eventSignUp.findUnique({
-			where: {
-				userId_eventId_active: {
-					userId,
-					eventId,
-					active: true,
+	async getActiveSignUp(
+		_ctx: Context,
+		params: { userId: string; eventId: string },
+	): ResultAsync<{ signUp: EventSignUp }, NotFoundError | InternalServerError> {
+		try {
+			const signUp = await this.db.eventSignUp.findUnique({
+				where: {
+					userId_eventId_active: {
+						userId: params.userId,
+						eventId: params.eventId,
+						active: true,
+					},
 				},
-			},
-		});
+			});
 
-		if (signUp === null) {
-			throw new NotFoundError(
-				`Event sign up { userId: ${userId}, eventId: ${eventId} } not found`,
-			);
+			if (signUp === null) {
+				return {
+					ok: false,
+					error: new NotFoundError(
+						`Sign up for user ${params.userId} and event ${params.eventId} not found`,
+					),
+				};
+			}
+
+			return {
+				ok: true,
+				data: {
+					signUp,
+				},
+			};
+		} catch (err) {
+			return {
+				ok: false,
+				error: new InternalServerError("Failed to get sign up", err),
+			};
 		}
-
-		return signUp;
 	}
 
 	findManySlots(data: { gradeYear?: number; eventId: string }): Promise<

--- a/src/services/events/__tests__/integration/can-sign-up.test.ts
+++ b/src/services/events/__tests__/integration/can-sign-up.test.ts
@@ -5,7 +5,7 @@ import { makeMockContext } from "~/lib/context.js";
 import prisma from "~/lib/prisma.js";
 import type { EventService } from "../../service.js";
 import {
-	makeDependencies,
+	makeServices,
 	makeUserWithOrganizationMembership,
 } from "./dependencies-factory.js";
 
@@ -13,7 +13,7 @@ describe("EventService", () => {
 	let eventService: EventService;
 
 	beforeAll(() => {
-		({ eventService } = makeDependencies());
+		({ eventService } = makeServices());
 	});
 
 	describe("canSignUpForEvent", () => {
@@ -295,7 +295,9 @@ describe("EventService", () => {
 						arrange.signUp.participationStatus === "RETRACTED" ||
 						arrange.signUp.participationStatus === "REMOVED"
 					) {
-						await eventService.retractSignUp(user.id, event.data.event.id);
+						await eventService.retractSignUp(ctx, {
+							eventId: event.data.event.id,
+						});
 					}
 				}
 
@@ -305,8 +307,8 @@ describe("EventService", () => {
 				 * Call the canSignUpForEvent function with the user and the event
 				 */
 				const actual = await eventService.canSignUpForEvent(
-					user.id,
-					event.data.event.id,
+					makeMockContext(user),
+					{ eventId: event.data.event.id },
 				);
 
 				/**
@@ -355,7 +357,10 @@ describe("EventService", () => {
 			 *
 			 * Call the canSignUpForEvent function with the user and the event
 			 */
-			const actual = await eventService.canSignUpForEvent(user.id, event.id);
+			const actual = await eventService.canSignUpForEvent(
+				makeMockContext(user),
+				{ eventId: event.id },
+			);
 
 			/**
 			 * Assert

--- a/src/services/events/__tests__/integration/change-sign-up-status.test.ts
+++ b/src/services/events/__tests__/integration/change-sign-up-status.test.ts
@@ -4,7 +4,7 @@ import { ParticipationStatus } from "@prisma/client";
 import { DateTime } from "luxon";
 import { makeTestServices } from "~/__tests__/dependencies-factory.js";
 import { InvalidArgumentError, NotFoundError } from "~/domain/errors.js";
-import { makeMockContext } from "~/lib/context.js";
+import { type Context, makeMockContext } from "~/lib/context.js";
 import type { Services } from "~/lib/server.js";
 import { makeUserWithOrganizationMembership } from "./dependencies-factory.js";
 
@@ -17,126 +17,42 @@ describe("EventService", () => {
 
 	describe("#retractSignUp", () => {
 		it("should retract confirmed sign up and increment the slot and event capacities", async () => {
-			const { user, organization } = await makeUserWithOrganizationMembership();
-			const ctx = makeMockContext(user);
+			const { user, ctx, event } = await makeDeps({ capacity: 1 });
 
-			const createEvent = await events.create(ctx, {
-				type: "SIGN_UPS",
-				event: {
-					organizationId: organization.id,
-					name: faker.word.adjective(),
-					startAt: DateTime.now().plus({ days: 1 }).toJSDate(),
-					endAt: DateTime.now().plus({ days: 2 }).toJSDate(),
-					signUpsEnabled: true,
-					capacity: 1,
-					signUpsEndAt: DateTime.now().plus({ days: 1 }).toJSDate(),
-					signUpsStartAt: DateTime.now().minus({ days: 1 }).toJSDate(),
-					signUpsRetractable: true,
-				},
-				slots: [
-					{
-						capacity: 1,
-					},
-				],
-			});
-
-			assert(createEvent.ok);
-			const { event } = createEvent.data;
-
-			await events.signUp(ctx, { userId: user.id, eventId: event.id });
 			const actual = await events.retractSignUp(user.id, event.id);
-			const actualEvent = await events.get(event.id);
-			const actualSlotsResult = await events.getSlots(ctx, {
-				eventId: event.id,
-			});
-			assert(actualSlotsResult.ok);
-			const { slots: actualSlots } = actualSlotsResult.data;
-			const actualSlot = actualSlots[0];
-			assert(actualSlot !== undefined);
+			const actualEvent = await mustGetEvent(event.id);
+			const actualSlot = await mustGetSlot(ctx, event.id);
 
-			expect(actual.participationStatus).toBe(ParticipationStatus.RETRACTED);
-			expect(actual.slotId).toBe(null);
-			expect(actual.version).toBe(1);
+			expect(actual).toEqual(
+				expect.objectContaining({
+					participationStatus: ParticipationStatus.RETRACTED,
+					slotId: null,
+					version: 1,
+				}),
+			);
 			expect(actualEvent.remainingCapacity).toBe(1);
 			expect(actualSlot.remainingCapacity).toBe(1);
 		});
 
 		it("retract wait list sign up and not increment the slot and event capacities", async () => {
-			const { user, organization } = await makeUserWithOrganizationMembership();
-			const ctx = makeMockContext(user);
-
-			const createEvent = await events.create(ctx, {
-				type: "SIGN_UPS",
-				event: {
-					organizationId: organization.id,
-					name: faker.word.adjective(),
-					startAt: DateTime.now().plus({ days: 1 }).toJSDate(),
-					endAt: DateTime.now().plus({ days: 2 }).toJSDate(),
-					signUpsEnabled: true,
-					capacity: 0,
-					signUpsEndAt: DateTime.now().plus({ days: 1 }).toJSDate(),
-					signUpsStartAt: DateTime.now().minus({ days: 1 }).toJSDate(),
-					signUpsRetractable: false,
-				},
-				slots: [
-					{
-						capacity: 0,
-					},
-				],
-			});
-
-			assert(createEvent.ok);
-			const { event } = createEvent.data;
-
-			await events.signUp(ctx, { userId: user.id, eventId: event.id });
+			const { user, ctx, event } = await makeDeps({ capacity: 0 });
 			const actual = await events.retractSignUp(user.id, event.id);
-			const actualEvent = await events.get(event.id);
-			const actualSlotsResult = await events.getSlots(ctx, {
-				eventId: event.id,
-			});
-			assert(actualSlotsResult.ok);
-			const { slots: actualSlots } = actualSlotsResult.data;
-			const actualSlot = actualSlots[0];
-			assert(actualSlot !== undefined);
+			const actualEvent = await mustGetEvent(event.id);
+			const actualSlot = await mustGetSlot(ctx, event.id);
 
-			expect(actual.participationStatus).toBe(ParticipationStatus.RETRACTED);
-			expect(actual.slotId).toBe(null);
-			expect(actual.version).toBe(1);
+			expect(actual).toEqual(
+				expect.objectContaining({
+					participationStatus: ParticipationStatus.RETRACTED,
+					slotId: null,
+					version: 1,
+				}),
+			);
 			expect(actualEvent.remainingCapacity).toBe(0);
 			expect(actualSlot.remainingCapacity).toBe(0);
 		});
 
 		it("not change an already retracted sign up", async () => {
-			const { user, organization } = await makeUserWithOrganizationMembership();
-			const ctx = makeMockContext(user);
-
-			const createEvent = await events.create(ctx, {
-				type: "SIGN_UPS",
-				event: {
-					organizationId: organization.id,
-					name: faker.word.adjective(),
-					startAt: DateTime.now().plus({ days: 1 }).toJSDate(),
-					endAt: DateTime.now().plus({ days: 2 }).toJSDate(),
-					signUpsEnabled: true,
-					capacity: 1,
-					signUpsEndAt: DateTime.now().plus({ days: 1 }).toJSDate(),
-					signUpsStartAt: DateTime.now().minus({ days: 1 }).toJSDate(),
-					signUpsRetractable: true,
-				},
-				slots: [
-					{
-						capacity: 1,
-					},
-				],
-			});
-
-			if (!createEvent.ok) {
-				throw createEvent.error;
-			}
-			assert(createEvent.ok);
-			const { event } = createEvent.data;
-
-			await events.signUp(ctx, { userId: user.id, eventId: event.id });
+			const { user, ctx, event } = await makeDeps({ capacity: 1 });
 			await events.retractSignUp(user.id, event.id);
 
 			try {
@@ -145,50 +61,18 @@ describe("EventService", () => {
 			} catch (err) {
 				expect(err).toBeInstanceOf(NotFoundError);
 			}
-			const actualEvent = await events.get(event.id);
-			const actualSlotsResult = await events.getSlots(ctx, {
-				eventId: event.id,
-			});
-
-			assert(actualSlotsResult.ok);
-			const { slots: actualSlots } = actualSlotsResult.data;
-			const actualSlot = actualSlots[0];
-			assert(actualSlot !== undefined);
+			const actualEvent = await mustGetEvent(event.id);
+			const actualSlot = await mustGetSlot(ctx, event.id);
 
 			expect(actualEvent.remainingCapacity).toBe(1);
 			expect(actualSlot.remainingCapacity).toBe(1);
 		});
 
 		it("should return InvalidArgumentError if trying to retract a confirmed sign up on a non-retractable event", async () => {
-			const { user, organization } = await makeUserWithOrganizationMembership();
-			const ctx = makeMockContext(user);
-
-			const createEvent = await events.create(ctx, {
-				type: "SIGN_UPS",
-				event: {
-					organizationId: organization.id,
-					name: faker.word.adjective(),
-					startAt: DateTime.now().plus({ days: 1 }).toJSDate(),
-					endAt: DateTime.now().plus({ days: 2 }).toJSDate(),
-					signUpsEnabled: true,
-					capacity: 1,
-					signUpsEndAt: DateTime.now().plus({ days: 1 }).toJSDate(),
-					signUpsStartAt: DateTime.now().minus({ days: 1 }).toJSDate(),
-					signUpsRetractable: false,
-				},
-				slots: [
-					{
-						capacity: 1,
-					},
-				],
+			const { event, user } = await makeDeps({
+				capacity: 1,
+				retractable: false,
 			});
-
-			if (!createEvent.ok) {
-				throw createEvent.error;
-			}
-			const { event } = createEvent.data;
-
-			await events.signUp(ctx, { userId: user.id, eventId: event.id });
 			try {
 				await events.retractSignUp(user.id, event.id);
 				fail("Expected an error");
@@ -198,40 +82,180 @@ describe("EventService", () => {
 		});
 
 		it("should retract a non-confirmed sign up on a non-retractable event", async () => {
-			const { user, organization } = await makeUserWithOrganizationMembership();
-			const ctx = makeMockContext(user);
-
-			const createEvent = await events.create(ctx, {
-				type: "SIGN_UPS",
-				event: {
-					organizationId: organization.id,
-					name: faker.word.adjective(),
-					startAt: DateTime.now().plus({ days: 1 }).toJSDate(),
-					endAt: DateTime.now().plus({ days: 2 }).toJSDate(),
-					signUpsEnabled: true,
-					capacity: 0,
-					signUpsEndAt: DateTime.now().plus({ days: 1 }).toJSDate(),
-					signUpsStartAt: DateTime.now().minus({ days: 1 }).toJSDate(),
-					signUpsRetractable: false,
-				},
-				slots: [
-					{
-						capacity: 1,
-					},
-				],
+			const { user, event } = await makeDeps({
+				capacity: 0,
+				retractable: false,
 			});
-
-			if (!createEvent.ok) {
-				throw createEvent.error;
-			}
-			const { event } = createEvent.data;
-
-			// wait list sign up
-			await events.signUp(ctx, { userId: user.id, eventId: event.id });
 			const retactSignUpResult = await events.retractSignUp(user.id, event.id);
 			expect(retactSignUpResult.participationStatus).toBe(
 				ParticipationStatus.RETRACTED,
 			);
 		});
 	});
+
+	describe("#removeSignUp", () => {
+		it("removes a confirmed sign up and increments the slot and event capacities", async () => {
+			const { signUp, ctx, event } = await makeDeps({ capacity: 1 });
+			const actual = await events.removeSignUp(ctx, { signUpId: signUp.id });
+
+			const actualEvent = await mustGetEvent(event.id);
+			const actualSlot = await mustGetSlot(ctx, event.id);
+
+			expect(actual).toEqual({
+				ok: true,
+				data: {
+					signUp: expect.objectContaining({
+						participationStatus: ParticipationStatus.REMOVED,
+						slotId: null,
+						version: 1,
+						id: signUp.id,
+					}),
+				},
+			});
+			expect(actualEvent.remainingCapacity).toBe(1);
+			expect(actualSlot.remainingCapacity).toBe(1);
+		});
+
+		it("removes a wait list sign up and does not increment the slot and event capacities", async () => {
+			const { signUp, ctx, event } = await makeDeps({ capacity: 0 });
+
+			const actual = await events.removeSignUp(ctx, { signUpId: signUp.id });
+
+			const actualEvent = await mustGetEvent(event.id);
+			const actualSlot = await mustGetSlot(ctx, event.id);
+
+			expect(actual).toEqual({
+				ok: true,
+				data: {
+					signUp: expect.objectContaining({
+						participationStatus: ParticipationStatus.REMOVED,
+						slotId: null,
+						version: 1,
+						id: signUp.id,
+					}),
+				},
+			});
+			expect(actualEvent.remainingCapacity).toBe(0);
+			expect(actualSlot.remainingCapacity).toBe(0);
+		});
+
+		it("does not change an already removed sign up", async () => {
+			const { signUp, ctx, event } = await makeDeps({ capacity: 1 });
+
+			const removed = await events.removeSignUp(ctx, { signUpId: signUp.id });
+			if (!removed.ok) throw removed.error;
+			const actual = await events.removeSignUp(ctx, { signUpId: signUp.id });
+
+			const actualEvent = await mustGetEvent(event.id);
+			const actualSlot = await mustGetSlot(ctx, event.id);
+
+			expect(actual).toEqual({
+				ok: true,
+				data: {
+					signUp: removed.data.signUp,
+				},
+			});
+			expect(actualEvent.remainingCapacity).toBe(1);
+			expect(actualSlot.remainingCapacity).toBe(1);
+		});
+
+		it("removes a confirmed sign up from a non-retractable event", async () => {
+			const { signUp, ctx, event } = await makeDeps({
+				capacity: 1,
+				retractable: false,
+			});
+
+			const actual = await events.removeSignUp(ctx, { signUpId: signUp.id });
+
+			const actualEvent = await mustGetEvent(event.id);
+			const actualSlot = await mustGetSlot(ctx, event.id);
+
+			expect(actual).toEqual({
+				ok: true,
+				data: {
+					signUp: expect.objectContaining({
+						participationStatus: ParticipationStatus.REMOVED,
+						slotId: null,
+						version: 1,
+						id: signUp.id,
+					}),
+				},
+			});
+			expect(actualEvent.remainingCapacity).toBe(1);
+			expect(actualSlot.remainingCapacity).toBe(1);
+		});
+
+		it("removes a wait list sign up on a non-retractable event", async () => {
+			const { signUp, ctx } = await makeDeps({
+				capacity: 0,
+				retractable: false,
+			});
+
+			const retactSignUpResult = await events.removeSignUp(ctx, {
+				signUpId: signUp.id,
+			});
+			expect(retactSignUpResult).toEqual({
+				ok: true,
+				data: {
+					signUp: expect.objectContaining({
+						participationStatus: ParticipationStatus.REMOVED,
+						slotId: null,
+						version: 1,
+						id: signUp.id,
+					}),
+				},
+			});
+		});
+	});
+
+	async function makeDeps(params: { capacity: number; retractable?: boolean }) {
+		const { user, organization } = await makeUserWithOrganizationMembership();
+		const ctx = makeMockContext(user);
+		const createEvent = await events.create(ctx, {
+			type: "SIGN_UPS",
+			event: {
+				organizationId: organization.id,
+				name: faker.word.adjective(),
+				startAt: DateTime.now().plus({ days: 1 }).toJSDate(),
+				endAt: DateTime.now().plus({ days: 2 }).toJSDate(),
+				signUpsEnabled: true,
+				capacity: params.capacity,
+				signUpsEndAt: DateTime.now().plus({ days: 1 }).toJSDate(),
+				signUpsStartAt: DateTime.now().minus({ days: 1 }).toJSDate(),
+				signUpsRetractable: params.retractable ?? true,
+			},
+			slots: [
+				{
+					capacity: params.capacity,
+				},
+			],
+		});
+
+		if (!createEvent.ok) throw createEvent.error;
+		const { event } = createEvent.data;
+
+		const signUpResult = await events.signUp(ctx, {
+			userId: user.id,
+			eventId: event.id,
+		});
+		if (!signUpResult.ok) throw signUpResult.error;
+		const { signUp } = signUpResult.data;
+
+		return { ctx, user, event, signUp };
+	}
+
+	async function mustGetEvent(id: string) {
+		const event = await events.get(id);
+		return event;
+	}
+
+	async function mustGetSlot(ctx: Context, eventId: string) {
+		const slotsResult = await events.getSlots(ctx, {
+			eventId,
+		});
+		if (!slotsResult.ok) throw slotsResult.error;
+		const slot = slotsResult.data.slots[0];
+		assert(slot !== undefined);
+		return slot;
+	}
 });

--- a/src/services/events/__tests__/integration/create.test.ts
+++ b/src/services/events/__tests__/integration/create.test.ts
@@ -13,7 +13,7 @@ import type { Result } from "~/lib/result.js";
 import type { Services } from "~/lib/server.js";
 import type { CreateEventParams } from "../../service.js";
 import {
-	makeDependencies,
+	makeServices,
 	makeUserWithOrganizationMembership,
 } from "./dependencies-factory.js";
 
@@ -196,7 +196,7 @@ describe("EventService", () => {
 					{ isSuperUser: true },
 				);
 				const ctx = makeMockContext(user);
-				const { productService } = makeDependencies();
+				const { productService } = makeServices();
 				const createMerchantResult = await productService.merchants.create(
 					ctx,
 					{
@@ -243,7 +243,7 @@ describe("EventService", () => {
 					{ isSuperUser: true },
 				);
 				const ctx = makeMockContext(user);
-				const { productService } = makeDependencies();
+				const { productService } = makeServices();
 				const createMerchantResult = await productService.merchants.create(
 					ctx,
 					{
@@ -291,7 +291,7 @@ describe("EventService", () => {
 					{ isSuperUser: true },
 				);
 				const ctx = makeMockContext(user);
-				const { productService } = makeDependencies();
+				const { productService } = makeServices();
 				const createMerchantResult = await productService.merchants.create(
 					ctx,
 					{

--- a/src/services/events/__tests__/integration/get-approximate-position-on-waiting-list.test.ts
+++ b/src/services/events/__tests__/integration/get-approximate-position-on-waiting-list.test.ts
@@ -8,14 +8,14 @@ import {
 } from "~/domain/errors.js";
 import { makeMockContext } from "~/lib/context.js";
 import {
-	makeDependencies,
+	makeServices,
 	makeUserWithOrganizationMembership,
 } from "./dependencies-factory.js";
 
 describe("EventService", () => {
 	describe("#getApproximatePositionOnWaitingList", () => {
 		it("returns the approximate position on the waiting list", async () => {
-			const { eventService } = makeDependencies();
+			const { eventService } = makeServices();
 			const { user, organization } = await makeUserWithOrganizationMembership();
 			const { user: otherUser } = await makeUserWithOrganizationMembership();
 			const ctx = makeMockContext(user);
@@ -64,7 +64,7 @@ describe("EventService", () => {
 		});
 
 		it("returns the approximate position on the waiting list if there are confirmed sign ups", async () => {
-			const { eventService } = makeDependencies();
+			const { eventService } = makeServices();
 			const { user, organization } = await makeUserWithOrganizationMembership();
 			const { user: otherUser } = await makeUserWithOrganizationMembership();
 			const ctx = makeMockContext(user);
@@ -113,7 +113,7 @@ describe("EventService", () => {
 		});
 
 		it("returns UnauthorizedError if the user is not logged in", async () => {
-			const { eventService } = makeDependencies();
+			const { eventService } = makeServices();
 
 			/**
 			 * Get the approximate position on the waiting list for the user.
@@ -132,7 +132,7 @@ describe("EventService", () => {
 		});
 
 		it("returns NotFoundError if the user does not have a sign up on the event", async () => {
-			const { eventService } = makeDependencies();
+			const { eventService } = makeServices();
 			const { user, organization } = await makeUserWithOrganizationMembership();
 			/**
 			 * Create an event
@@ -172,7 +172,7 @@ describe("EventService", () => {
 		});
 
 		it("returns InvalidArgumentError if the user is not on the wait list", async () => {
-			const { eventService } = makeDependencies();
+			const { eventService } = makeServices();
 			const { user, organization } = await makeUserWithOrganizationMembership();
 			/**
 			 * Create an event
@@ -219,7 +219,7 @@ describe("EventService", () => {
 		});
 
 		it("returns InvalidArgumentError if the event does not exist", async () => {
-			const { eventService } = makeDependencies();
+			const { eventService } = makeServices();
 			const { user } = await makeUserWithOrganizationMembership();
 
 			/**

--- a/src/services/events/__tests__/integration/promote-from-waitlist.test.ts
+++ b/src/services/events/__tests__/integration/promote-from-waitlist.test.ts
@@ -7,7 +7,7 @@ import { makeMockContext } from "~/lib/context.js";
 import prisma from "~/lib/prisma.js";
 import type { EventService } from "../../service.js";
 import {
-	makeDependencies,
+	makeServices,
 	makeUserWithOrganizationMembership,
 } from "./dependencies-factory.js";
 
@@ -15,7 +15,7 @@ describe("EventService", () => {
 	let eventService: EventService;
 
 	beforeAll(() => {
-		({ eventService } = makeDependencies());
+		({ eventService } = makeServices());
 	});
 
 	describe("promoteFromWaitlist", () => {

--- a/src/services/events/__tests__/integration/sign-off-waitlist-promotion.test.ts
+++ b/src/services/events/__tests__/integration/sign-off-waitlist-promotion.test.ts
@@ -232,7 +232,9 @@ describe("EventService", () => {
 			 *
 			 * Retract the confirmed user's sign up, and wait for jobs to finish
 			 */
-			await eventService.retractSignUp(confirmedUser.id, event.id);
+			await eventService.retractSignUp(makeMockContext(confirmedUser), {
+				eventId: event.id,
+			});
 			const signUpJobs = await signUpQueue.getJobs();
 			await Promise.all(
 				signUpJobs.map((job) =>
@@ -258,13 +260,15 @@ describe("EventService", () => {
 			 * The promoted user should receive an email.
 			 */
 			const retractedSignUp = await eventService.getSignUpAvailability(
-				confirmedUser.id,
-				event.id,
+				makeMockContext(confirmedUser),
+				{
+					eventId: event.id,
+				},
 			);
 			expect(retractedSignUp).toBe("WAITLIST_AVAILABLE");
 			const promotedSignUp = await eventService.getSignUpAvailability(
-				waitListUser.id,
-				event.id,
+				makeMockContext(waitListUser),
+				{ eventId: event.id },
 			);
 			expect(promotedSignUp).toBe("CONFIRMED");
 			expect(mailClient.sendEmailWithTemplate).toHaveBeenCalledWith(
@@ -416,7 +420,9 @@ describe("EventService", () => {
 			 */
 			await Promise.all(
 				confirmedUsers.map((user) =>
-					eventService.retractSignUp(user.id, event.id),
+					eventService.retractSignUp(makeMockContext(user), {
+						eventId: event.id,
+					}),
 				),
 			);
 			const signUpJobs = await signUpQueue.getJobs();
@@ -445,15 +451,15 @@ describe("EventService", () => {
 			 */
 			for (const user of confirmedUsers) {
 				const retractedSignUp = await eventService.getSignUpAvailability(
-					user.id,
-					event.id,
+					makeMockContext(user),
+					{ eventId: event.id },
 				);
 				expect(retractedSignUp).toBe("WAITLIST_AVAILABLE");
 			}
 			for (const user of waitListUsers) {
 				const promotedSignUp = await eventService.getSignUpAvailability(
-					user.id,
-					event.id,
+					makeMockContext(user),
+					{ eventId: event.id },
 				);
 				expect(promotedSignUp).toBe("CONFIRMED");
 				expect(mailClient.sendEmailWithTemplate).toHaveBeenCalledWith(
@@ -474,8 +480,8 @@ describe("EventService", () => {
 
 			for (const user of shouldRemainOnWaitListUsers) {
 				const signUpAvailability = await eventService.getSignUpAvailability(
-					user.id,
-					event.id,
+					makeMockContext(user),
+					{ eventId: event.id },
 				);
 				expect(signUpAvailability).toBe("ON_WAITLIST");
 			}

--- a/src/services/events/__tests__/integration/sign-up.test.ts
+++ b/src/services/events/__tests__/integration/sign-up.test.ts
@@ -7,13 +7,13 @@ import { type User, newUserFromDSO } from "~/domain/users.js";
 import { makeMockContext } from "~/lib/context.js";
 import prisma from "~/lib/prisma.js";
 import type { EventService } from "../../service.js";
-import { makeDependencies } from "./dependencies-factory.js";
+import { makeServices } from "./dependencies-factory.js";
 
 describe("Event Sign Up", () => {
 	let eventService: EventService;
 
 	beforeAll(() => {
-		({ eventService } = makeDependencies());
+		({ eventService } = makeServices());
 	});
 
 	describe("signUp", () => {
@@ -148,7 +148,7 @@ describe("Event Sign Up", () => {
 			 * 3. Create a slot for the event with capacity.
 			 * 4. Create a user to sign up for the event.
 			 */
-			const { productService } = makeDependencies();
+			const { productService } = makeServices();
 			const { organization, user } = await makeUserWithOrganizationMembership({
 				isSuperUser: true,
 			});

--- a/src/services/events/__tests__/unit/get-order-for-sign-up.test.ts
+++ b/src/services/events/__tests__/unit/get-order-for-sign-up.test.ts
@@ -47,11 +47,14 @@ describe("EventService", () => {
 		});
 
 		it("should return NotFoundError if the sign up is not confirmed", async () => {
-			mockEventRepository.getSignUp.mockResolvedValueOnce(
-				mock<EventSignUp>({
-					participationStatus: "ON_WAITLIST",
-				}),
-			);
+			mockEventRepository.getActiveSignUp.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					signUp: mock<EventSignUp>({
+						participationStatus: "ON_WAITLIST",
+					}),
+				},
+			});
 
 			const user = mock<User>({ id: faker.string.uuid() });
 			const ctx = makeMockContext(user);
@@ -67,12 +70,15 @@ describe("EventService", () => {
 		});
 
 		it("should return NotFoundError if the sign up does not have an order", async () => {
-			mockEventRepository.getSignUp.mockResolvedValueOnce(
-				mock<EventSignUp>({
-					participationStatus: "CONFIRMED",
-					orderId: null,
-				}),
-			);
+			mockEventRepository.getActiveSignUp.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					signUp: mock<EventSignUp>({
+						participationStatus: "CONFIRMED",
+						orderId: null,
+					}),
+				},
+			});
 
 			const user = mock<User>({ id: faker.string.uuid() });
 			const ctx = makeMockContext(user);
@@ -88,12 +94,15 @@ describe("EventService", () => {
 		});
 
 		it("should return the order if found", async () => {
-			mockEventRepository.getSignUp.mockResolvedValueOnce(
-				mock<EventSignUp>({
-					participationStatus: "CONFIRMED",
-					orderId: faker.string.uuid(),
-				}),
-			);
+			mockEventRepository.getActiveSignUp.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					signUp: mock<EventSignUp>({
+						participationStatus: "CONFIRMED",
+						orderId: faker.string.uuid(),
+					}),
+				},
+			});
 			mockProductService.orders.get.mockResolvedValue({
 				ok: true,
 				data: {
@@ -129,12 +138,15 @@ describe("EventService", () => {
 		});
 
 		it("should use the user ID from context if not a super user", async () => {
-			mockEventRepository.getSignUp.mockResolvedValueOnce(
-				mock<EventSignUp>({
-					participationStatus: "CONFIRMED",
-					orderId: faker.string.uuid(),
-				}),
-			);
+			mockEventRepository.getActiveSignUp.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					signUp: mock<EventSignUp>({
+						participationStatus: "CONFIRMED",
+						orderId: faker.string.uuid(),
+					}),
+				},
+			});
 			mockProductService.orders.get.mockResolvedValue({
 				ok: true,
 				data: {
@@ -162,19 +174,25 @@ describe("EventService", () => {
 				userId: faker.string.uuid(),
 			});
 
-			expect(mockEventRepository.getSignUp).toHaveBeenCalledWith(
-				user.id,
-				expect.any(String),
+			expect(mockEventRepository.getActiveSignUp).toHaveBeenCalledWith(
+				expect.anything(),
+				{
+					userId: user.id,
+					eventId: expect.any(String),
+				},
 			);
 		});
 
 		it("should use the userId parameter if the user is a super user", async () => {
-			mockEventRepository.getSignUp.mockResolvedValueOnce(
-				mock<EventSignUp>({
-					participationStatus: "CONFIRMED",
-					orderId: faker.string.uuid(),
-				}),
-			);
+			mockEventRepository.getActiveSignUp.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					signUp: mock<EventSignUp>({
+						participationStatus: "CONFIRMED",
+						orderId: faker.string.uuid(),
+					}),
+				},
+			});
 			mockProductService.orders.get.mockResolvedValue({
 				ok: true,
 				data: {
@@ -203,9 +221,12 @@ describe("EventService", () => {
 				userId: otherUserId,
 			});
 
-			expect(mockEventRepository.getSignUp).toHaveBeenCalledWith(
-				otherUserId,
-				expect.any(String),
+			expect(mockEventRepository.getActiveSignUp).toHaveBeenCalledWith(
+				expect.anything(),
+				{
+					userId: otherUserId,
+					eventId: expect.any(String),
+				},
 			);
 		});
 	});


### PR DESCRIPTION
### Changes
- Add support for removing sign ups from events as an organization member
- Use ctx for more methods in events service, add more auth checks