### PR TITLE
:bug: fix: determine calendar day state from valid booking intervals

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,9 +16,9 @@
 				"useAwait": "warn"
 			},
 			"correctness": {
-				"noUnusedImports": "error",
-				"noUnusedVariables": "error",
-				"noUnusedPrivateClassMembers": "error"
+				"noUnusedImports": "warn",
+				"noUnusedVariables": "warn",
+				"noUnusedPrivateClassMembers": "warn"
 			},
 			"nursery": {
 				"recommended": true

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { FastifyBaseLogger } from "fastify";
 import { isNil, merge } from "lodash-es";
+import { pino } from "pino";
+import { env } from "~/config.js";
 import type { User } from "~/domain/users.js";
+import { envToLogger } from "./fastify/logging.js";
 
 export type Context = {
 	user: User | null;
@@ -31,20 +34,25 @@ export function makeMockContext(
 		username: randomUUID(),
 		studyProgramId: null,
 	};
+	let defaultLogger: FastifyBaseLogger = {
+		child() {
+			return this;
+		},
+		debug() {},
+		error() {},
+		info() {},
+		fatal() {},
+		warn() {},
+		trace() {},
+		silent() {},
+		level: "debug",
+	};
+	if (env.LOG_ENABLED) {
+		defaultLogger = pino(envToLogger.test);
+	}
+
 	return {
 		user: isNil(user) ? null : merge(mockUser, user),
-		log: log ?? {
-			child() {
-				return this;
-			},
-			debug() {},
-			error() {},
-			info() {},
-			fatal() {},
-			warn() {},
-			trace() {},
-			silent() {},
-			level: "debug",
-		},
+		log: log ?? defaultLogger,
 	};
 }

--- a/src/services/cabins/__tests__/unit/booking-semester.test.ts
+++ b/src/services/cabins/__tests__/unit/booking-semester.test.ts
@@ -102,7 +102,9 @@ describe("CabinService", () => {
 			expect(cabinRepository.updateBookingSemester).toHaveBeenCalledWith({
 				semester: Semester.SPRING,
 				startAt: new Date(2020, 0, 1),
-				endAt: new Date(2020, 0, 2),
+				endAt: DateTime.fromObject({ year: 2020, month: 1, day: 2 })
+					.endOf("day")
+					.toJSDate(),
 				bookingsEnabled: true,
 			});
 		});
@@ -182,7 +184,13 @@ describe("CabinService", () => {
 				expect(cabinRepository.createBookingSemester).toHaveBeenCalledWith({
 					semester: Semester.SPRING,
 					startAt: new Date(2020, 0, 1),
-					endAt: new Date(2020, 0, 2),
+					endAt: DateTime.fromObject({
+						year: 2020,
+						month: 1,
+						day: 2,
+					})
+						.endOf("day")
+						.toJSDate(),
 					bookingsEnabled: true,
 				});
 			});
@@ -221,7 +229,9 @@ describe("CabinService", () => {
 				expect(cabinRepository.createBookingSemester).toHaveBeenCalledWith({
 					semester: Semester.SPRING,
 					startAt: DateTime.fromObject({ month: 1, day: 1 }).toJSDate(),
-					endAt: DateTime.fromObject({ month: 7, day: 31 }).toJSDate(),
+					endAt: DateTime.fromObject({ month: 7, day: 31 })
+						.endOf("day")
+						.toJSDate(),
 					bookingsEnabled: true,
 				});
 			});
@@ -260,7 +270,9 @@ describe("CabinService", () => {
 				expect(cabinRepository.createBookingSemester).toHaveBeenCalledWith({
 					semester: Semester.FALL,
 					startAt: DateTime.fromObject({ month: 8, day: 1 }).toJSDate(),
-					endAt: DateTime.fromObject({ month: 12, day: 31 }).toJSDate(),
+					endAt: DateTime.fromObject({ month: 12, day: 31 })
+						.endOf("day")
+						.toJSDate(),
 					bookingsEnabled: true,
 				});
 			});
@@ -300,7 +312,13 @@ describe("CabinService", () => {
 				expect(cabinRepository.createBookingSemester).toHaveBeenCalledWith({
 					semester: Semester.SPRING,
 					startAt: new Date(2020, 0, 1),
-					endAt: new Date(2020, 0, 2),
+					endAt: DateTime.fromObject({
+						year: 2020,
+						month: 1,
+						day: 2,
+					})
+						.endOf("day")
+						.toJSDate(),
 					bookingsEnabled: false,
 				});
 			});

--- a/src/services/cabins/__tests__/unit/get-availability-calendar.test.ts
+++ b/src/services/cabins/__tests__/unit/get-availability-calendar.test.ts
@@ -348,7 +348,7 @@ describe("Cabin Service", () => {
 			});
 
 			const result = await cabinService.getAvailabilityCalendar(
-				makeMockContext(),
+				makeMockContext({}),
 				{
 					cabins: [{ id: faker.string.uuid() }],
 					count: 12,
@@ -434,7 +434,7 @@ describe("Cabin Service", () => {
 			});
 
 			const result = await cabinService.getAvailabilityCalendar(
-				makeMockContext(),
+				makeMockContext({}),
 				{
 					cabins: [{ id: faker.string.uuid() }],
 					count: 12,
@@ -451,6 +451,7 @@ describe("Cabin Service", () => {
 			const { calendarMonths } = result.data;
 			// the first day should not be, as the booking semester starts that day
 			expect(calendarMonths[0]?.days[0]?.availableForCheckOut).toBe(false);
+			expect(calendarMonths[0]?.days[0]?.bookable).toBe(true);
 			// the second day should, as there is a booking semester and no booking
 			expect(calendarMonths[0]?.days[1]?.availableForCheckOut).toBe(true);
 			// the third day should not, as there is a booking starting on the third and fourth day
@@ -463,6 +464,196 @@ describe("Cabin Service", () => {
 			expect(calendarMonths[0]?.days[6]?.availableForCheckOut).toBe(false);
 			// the eight should, as there is a booking semester and no booking
 			expect(calendarMonths[0]?.days[7]?.availableForCheckOut).toBe(true);
+		});
+
+		it("returns available: false for days that are squeezed between bookings, and there is no minimum interval available", async () => {
+			mockCabinRepository.getCabinById.mockResolvedValue(makeCabin());
+			mockCabinRepository.getBookingSemester.mockResolvedValueOnce(
+				makeBookingSemester({
+					bookingsEnabled: true,
+					startAt: DateTime.fromObject({
+						year: 2024,
+						month: 1,
+						day: 1,
+					}).toJSDate(),
+					endAt: DateTime.fromObject({
+						year: 2024,
+						month: 1,
+						day: 31,
+					}).toJSDate(),
+				}),
+			);
+			mockCabinRepository.findManyBookings.mockResolvedValue({
+				ok: true,
+				data: {
+					bookings: [
+						makeBooking({
+							startDate: DateTime.fromObject({
+								year: 2024,
+								month: 1,
+								day: 1,
+							}).toJSDate(),
+							endDate: DateTime.fromObject({
+								year: 2024,
+								month: 1,
+								day: 2,
+							}).toJSDate(),
+							status: "CONFIRMED",
+						}),
+						makeBooking({
+							startDate: DateTime.fromObject({
+								year: 2024,
+								month: 1,
+								day: 4,
+							}).toJSDate(),
+							endDate: DateTime.fromObject({
+								year: 2024,
+								month: 1,
+								day: 5,
+							}).toJSDate(),
+							status: "CONFIRMED",
+						}),
+					],
+					total: 2,
+				},
+			});
+
+			const result = await cabinService.getAvailabilityCalendar(
+				makeMockContext(),
+				{
+					cabins: [{ id: faker.string.uuid() }],
+					count: 12,
+					guests: {
+						external: 10,
+						internal: 10,
+					},
+					month: 1,
+					year: 2024,
+				},
+			);
+			if (!result.ok) throw result.error;
+
+			const { calendarMonths } = result.data;
+			// the third day is squeezed between two unbookable days, and should not be bookable
+			expect(calendarMonths[0]?.days[2]?.bookable).toBe(false);
+		});
+
+		it("returns available: false for days that are squeezed between bookings and a bookable date, and there is no minimum interval available", async () => {
+			mockCabinRepository.getCabinById.mockResolvedValue(makeCabin());
+			mockCabinRepository.getBookingSemester.mockResolvedValueOnce(
+				makeBookingSemester({
+					bookingsEnabled: true,
+					startAt: DateTime.fromObject({
+						year: 2024,
+						month: 1,
+						day: 1,
+					}).toJSDate(),
+					endAt: DateTime.fromObject({
+						year: 2024,
+						month: 1,
+						day: 31,
+					}).toJSDate(),
+				}),
+			);
+			mockCabinRepository.findManyBookings.mockResolvedValue({
+				ok: true,
+				data: {
+					bookings: [
+						makeBooking({
+							startDate: DateTime.fromObject({
+								year: 2024,
+								month: 1,
+								day: 1,
+							}).toJSDate(),
+							endDate: DateTime.fromObject({
+								year: 2024,
+								month: 1,
+								day: 30,
+							}).toJSDate(),
+							status: "CONFIRMED",
+						}),
+					],
+					total: 1,
+				},
+			});
+
+			const result = await cabinService.getAvailabilityCalendar(
+				makeMockContext(),
+				{
+					cabins: [{ id: faker.string.uuid() }],
+					count: 12,
+					guests: {
+						external: 10,
+						internal: 10,
+					},
+					month: 1,
+					year: 2024,
+				},
+			);
+			if (!result.ok) throw result.error;
+
+			const { calendarMonths } = result.data;
+			// the third day is squeezed between two unbookable days, and should not be available
+			expect(calendarMonths[0]?.days[30]?.bookable).toBe(false);
+		});
+
+		it("returns available: false for days that are squeezed between bookings and the past, and there is no minimum interval available", async () => {
+			mockCabinRepository.getCabinById.mockResolvedValue(makeCabin());
+			mockCabinRepository.getBookingSemester.mockResolvedValueOnce(
+				makeBookingSemester({
+					bookingsEnabled: true,
+					startAt: DateTime.fromObject({
+						year: 2023,
+						month: 1,
+						day: 1,
+					}).toJSDate(),
+					endAt: DateTime.fromObject({
+						year: 2024,
+						month: 1,
+						day: 31,
+					}).toJSDate(),
+				}),
+			);
+			mockCabinRepository.findManyBookings.mockResolvedValue({
+				ok: true,
+				data: {
+					bookings: [
+						makeBooking({
+							startDate: DateTime.fromObject({
+								year: 2024,
+								month: 1,
+								day: 2,
+							}).toJSDate(),
+							endDate: DateTime.fromObject({
+								year: 2024,
+								month: 1,
+								day: 30,
+							}).toJSDate(),
+							status: "CONFIRMED",
+						}),
+					],
+					total: 1,
+				},
+			});
+
+			const result = await cabinService.getAvailabilityCalendar(
+				makeMockContext(),
+				{
+					cabins: [{ id: faker.string.uuid() }],
+					count: 12,
+					guests: {
+						external: 10,
+						internal: 10,
+					},
+					month: 1,
+					year: 2024,
+				},
+			);
+			if (!result.ok) throw result.error;
+
+			const { calendarMonths } = result.data;
+			// the third day is squeezed between two unbookable days, and should not be available
+			expect(calendarMonths[0]?.days[0]?.bookable).toBe(false);
 		});
 
 		describe("price", () => {
@@ -585,21 +776,36 @@ function makeCabin(data?: Partial<Cabin>): Cabin {
 }
 
 function makeBookingSemester(data?: Partial<BookingSemester>): BookingSemester {
+	const { startAt, endAt, ...rest } = data ?? {};
+	const endAtDateTime = endAt
+		? DateTime.fromJSDate(endAt).endOf("day").toJSDate()
+		: DateTime.fromObject({ year: 3000 }).endOf("day").toJSDate();
+	const startAtDateTime = startAt
+		? DateTime.fromJSDate(startAt).startOf("day").toJSDate()
+		: DateTime.fromObject({ year: 3000 }).startOf("day").toJSDate();
 	return merge<BookingSemester, Partial<BookingSemester> | undefined>(
 		{
 			id: faker.string.uuid(),
 			bookingsEnabled: true,
 			createdAt: faker.date.recent(),
-			endAt: DateTime.fromObject({ year: 3000 }).toJSDate(),
-			startAt: DateTime.fromObject({ year: 2000 }).toJSDate(),
+			endAt: endAtDateTime,
+			startAt: startAtDateTime,
 			semester: "FALL",
 			updatedAt: faker.date.recent(),
 		},
-		data,
+		rest,
 	);
 }
 
 function makeBooking(data?: Partial<BookingType>): BookingType {
+	const { startDate, endDate, ...rest } = data ?? {};
+	const endAtDateTime = endDate
+		? DateTime.fromJSDate(endDate).endOf("day").toJSDate()
+		: DateTime.fromObject({ year: 2500, month: 2, day: 1 }).toJSDate();
+	const startAtDateTime = startDate
+		? DateTime.fromJSDate(startDate).startOf("day").toJSDate()
+		: DateTime.fromObject({ year: 2500, month: 1, day: 1 }).toJSDate();
+
 	return merge<BookingType, Partial<BookingType> | undefined>(
 		{
 			id: faker.string.uuid(),
@@ -608,12 +814,8 @@ function makeBooking(data?: Partial<BookingType>): BookingType {
 			firstName: faker.person.firstName(),
 			lastName: faker.person.lastName(),
 			phoneNumber: faker.phone.number(),
-			endDate: DateTime.fromObject({ year: 2500, month: 2, day: 1 }).toJSDate(),
-			startDate: DateTime.fromObject({
-				year: 2500,
-				month: 1,
-				day: 1,
-			}).toJSDate(),
+			endDate: endAtDateTime,
+			startDate: startAtDateTime,
 			status: "CONFIRMED",
 			totalCost: 100,
 			internalParticipantsCount: 10,
@@ -622,6 +824,6 @@ function makeBooking(data?: Partial<BookingType>): BookingType {
 			feedback: faker.lorem.sentence(),
 			cabins: [{ id: faker.string.uuid() }],
 		},
-		data,
+		rest,
 	);
 }

--- a/src/services/cabins/__tests__/unit/new-booking.test.ts
+++ b/src/services/cabins/__tests__/unit/new-booking.test.ts
@@ -118,7 +118,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								email: "fake",
 							}),
 						},
@@ -140,7 +140,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								phoneNumber: "fake",
 							}),
 						},
@@ -162,7 +162,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								cabins: [{ id: "fake" }],
 							}),
 						},
@@ -184,7 +184,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								firstName: "",
 							}),
 						},
@@ -206,7 +206,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								lastName: "",
 							}),
 						},
@@ -235,7 +235,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: faker.date.past(),
 							}),
 						},
@@ -257,7 +257,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								endDate: faker.date.past(),
 							}),
 						},
@@ -279,7 +279,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.now().plus({ days: 3 }).toJSDate(),
 								endDate: DateTime.now().plus({ days: 2 }).toJSDate(),
 							}),
@@ -302,7 +302,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.fromObject({
 									year: 2500,
 									day: 1,
@@ -340,7 +340,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput(),
+							input: makeBookingInput(),
 						},
 						expected: {
 							error: expect.objectContaining({
@@ -364,7 +364,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput(),
+							input: makeBookingInput(),
 						},
 						expected: {
 							error: expect.objectContaining({
@@ -390,7 +390,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.now().plus({ days: 1 }).toJSDate(),
 							}),
 						},
@@ -414,7 +414,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								endDate: DateTime.now().plus({ days: 3 }).toJSDate(),
 							}),
 						},
@@ -440,7 +440,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								endDate: DateTime.now().plus({ days: 3 }).toJSDate(),
 							}),
 						},
@@ -465,21 +465,15 @@ describe("CabinService", () => {
 						arrange: {
 							bookingSemesters: {
 								fall: makeBookingSemester({
-									endAt: DateTime.now()
-										.plus({ days: 1 })
-										.endOf("day")
-										.toJSDate(),
+									endAt: DateTime.now().plus({ days: 1 }).toJSDate(),
 								}),
 								spring: makeBookingSemester({
-									startAt: DateTime.now()
-										.plus({ days: 3 })
-										.startOf("day")
-										.toJSDate(),
+									startAt: DateTime.now().plus({ days: 3 }).toJSDate(),
 								}),
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.now().plus({ hour: 1 }).toJSDate(),
 								endDate: DateTime.now().plus({ days: 4 }).toJSDate(),
 							}),
@@ -498,22 +492,16 @@ describe("CabinService", () => {
 						arrange: {
 							bookingSemesters: {
 								fall: makeBookingSemester({
-									endAt: DateTime.now()
-										.plus({ days: 1 })
-										.endOf("day")
-										.toJSDate(),
+									endAt: DateTime.now().plus({ days: 1 }).toJSDate(),
 								}),
 								spring: makeBookingSemester({
-									startAt: DateTime.now()
-										.plus({ days: 2 })
-										.startOf("day")
-										.toJSDate(),
+									startAt: DateTime.now().plus({ days: 2 }).toJSDate(),
 									bookingsEnabled: false,
 								}),
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.now().plus({ hour: 1 }).toJSDate(),
 								endDate: DateTime.now().plus({ days: 4 }).toJSDate(),
 							}),
@@ -532,22 +520,16 @@ describe("CabinService", () => {
 						arrange: {
 							bookingSemesters: {
 								fall: makeBookingSemester({
-									endAt: DateTime.now()
-										.plus({ days: 1 })
-										.endOf("day")
-										.toJSDate(),
+									endAt: DateTime.now().plus({ days: 1 }).toJSDate(),
 									bookingsEnabled: false,
 								}),
 								spring: makeBookingSemester({
-									startAt: DateTime.now()
-										.plus({ days: 2 })
-										.startOf("day")
-										.toJSDate(),
+									startAt: DateTime.now().plus({ days: 2 }).toJSDate(),
 								}),
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.now().plus({ hour: 1 }).toJSDate(),
 								endDate: DateTime.now().plus({ days: 4 }).toJSDate(),
 							}),
@@ -573,21 +555,15 @@ describe("CabinService", () => {
 						arrange: {
 							bookingSemesters: {
 								fall: makeBookingSemester({
-									startAt: DateTime.now()
-										.plus({ days: 3 })
-										.startOf("day")
-										.toJSDate(),
+									startAt: DateTime.now().plus({ days: 3 }).toJSDate(),
 								}),
 								spring: makeBookingSemester({
-									endAt: DateTime.now()
-										.plus({ days: 1 })
-										.endOf("day")
-										.toJSDate(),
+									endAt: DateTime.now().plus({ days: 1 }).toJSDate(),
 								}),
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.now().plus({ hour: 1 }).toJSDate(),
 								endDate: DateTime.now().plus({ days: 4 }).toJSDate(),
 							}),
@@ -620,7 +596,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.fromObject({
 									year: 2499,
 									month: 12,
@@ -661,7 +637,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.fromObject({
 									year: 2499,
 									month: 12,
@@ -781,7 +757,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.fromObject({
 									year: 2500,
 									day: 1,
@@ -809,15 +785,9 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
-								startDate: DateTime.now()
-									.plus({ days: 1 })
-									.startOf("day")
-									.toJSDate(),
-								endDate: DateTime.now()
-									.plus({ days: 2 })
-									.startOf("day")
-									.toJSDate(),
+							input: makeBookingInput({
+								startDate: DateTime.now().plus({ days: 1 }).toJSDate(),
+								endDate: DateTime.now().plus({ days: 2 }).toJSDate(),
 							}),
 						},
 					},
@@ -830,15 +800,9 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
-								startDate: DateTime.now()
-									.plus({ days: 1 })
-									.startOf("day")
-									.toJSDate(),
-								endDate: DateTime.now()
-									.plus({ days: 2 })
-									.startOf("day")
-									.toJSDate(),
+							input: makeBookingInput({
+								startDate: DateTime.now().plus({ days: 1 }).toJSDate(),
+								endDate: DateTime.now().plus({ days: 2 }).toJSDate(),
 							}),
 						},
 					},
@@ -870,7 +834,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.fromObject({
 									year: 2499,
 									day: 31,
@@ -912,7 +876,7 @@ describe("CabinService", () => {
 							},
 						},
 						act: {
-							input: makeCabinInput({
+							input: makeBookingInput({
 								startDate: DateTime.fromObject({
 									year: 2499,
 									day: 31,
@@ -950,7 +914,7 @@ describe("CabinService", () => {
 				externalPriceWeekend: 250,
 				capacity: 5,
 			});
-			const input = makeCabinInput({
+			const input = makeBookingInput({
 				cabins: [cabin1, cabin2],
 				internalParticipantsCount: 6,
 				externalParticipantsCount: 5,
@@ -1012,7 +976,7 @@ describe("CabinService", () => {
 					},
 					pino(envToLogger.test),
 				),
-				makeCabinInput(),
+				makeBookingInput(),
 			);
 
 			/**
@@ -1045,7 +1009,7 @@ describe("CabinService", () => {
 				externalPriceWeekend: 250,
 				capacity: 5,
 			});
-			const input = makeCabinInput();
+			const input = makeBookingInput();
 			cabinRepository.getBookingSemester.mockResolvedValue(bookingSemester);
 			cabinRepository.getCabinById.mockResolvedValue(cabin);
 			cabinRepository.findManyBookings.mockResolvedValue({
@@ -1084,16 +1048,21 @@ describe("CabinService", () => {
 	});
 });
 
-function makeCabinInput(
+function makeBookingInput(
 	data: Partial<NewBookingParams> = {},
 ): NewBookingParams {
-	const startDate = DateTime.now().plus({ days: 1 }).toJSDate();
-	const endDate = DateTime.fromJSDate(startDate).plus({ days: 1 }).toJSDate();
+	const { startDate, endDate } = data;
+	const startAtDateTime = startDate
+		? DateTime.fromJSDate(startDate).startOf("day")
+		: DateTime.now().plus({ days: 1 }).startOf("day");
+	const endAtDateTime = endDate
+		? DateTime.fromJSDate(endDate).endOf("day")
+		: startAtDateTime.plus({ days: 1 });
 	return merge<NewBookingParams, Partial<NewBookingParams>>(
 		{
 			cabins: [{ id: faker.string.uuid() }],
-			startDate,
-			endDate,
+			startDate: startAtDateTime.toJSDate(),
+			endDate: endAtDateTime.toJSDate(),
 			phoneNumber: "40000000",
 			email: faker.internet.email(),
 			firstName: faker.person.firstName(),
@@ -1108,16 +1077,23 @@ function makeCabinInput(
 function makeBookingSemester(
 	data: Partial<BookingSemester> = {},
 ): BookingSemester {
+	const { startAt, endAt, ...rest } = data ?? {};
+	const start = startAt
+		? DateTime.fromJSDate(startAt).startOf("day").toJSDate()
+		: DateTime.fromObject({ year: 1000 }).toJSDate();
+	const end = endAt
+		? DateTime.fromJSDate(endAt).endOf("day").toJSDate()
+		: DateTime.fromObject({ year: 3000 }).toJSDate();
 	return merge<BookingSemester, Partial<BookingSemester>>(
 		{
 			id: faker.string.uuid(),
 			createdAt: faker.date.past(),
 			updatedAt: faker.date.past(),
 			semester: Semester.FALL,
-			startAt: DateTime.fromObject({ year: 1000 }).toJSDate(),
-			endAt: DateTime.fromObject({ year: 3000 }).toJSDate(),
+			startAt: start,
+			endAt: end,
 			bookingsEnabled: true,
 		},
-		data,
+		rest,
 	);
 }

--- a/src/services/cabins/service.ts
+++ b/src/services/cabins/service.ts
@@ -1282,10 +1282,18 @@ export class CabinService implements ICabinService {
 		for (const bookingSemester of bookingSemesters) {
 			if (bookingSemester.bookingsEnabled) {
 				const now = DateTime.now().startOf("day");
+				/**
+				 * Take the maximum of the start date of the booking semester and now, to ensure that we don't
+				 * include dates in the past.
+				 */
 				const startAt = DateTime.max(
 					DateTime.fromJSDate(bookingSemester.startAt).startOf("day"),
 					now,
 				);
+				/**
+				 * Offset endAt by 1 day (startOf) to account for the fact that intervals are half-open,
+				 * and we want to include the end date in the interval.
+				 */
 				const endAt = DateTime.fromJSDate(bookingSemester.endAt)
 					.plus({ days: 1 })
 					.startOf("day");
@@ -1324,6 +1332,10 @@ export class CabinService implements ICabinService {
 			}
 			for (const booking of bookings.data.bookings) {
 				const startAt = DateTime.fromJSDate(booking.startDate).startOf("day");
+				/**
+				 * Offset endAt by 1 day (startOf) to account for the fact that intervals are half-open,
+				 * and we want to include the end date in the interval.
+				 */
 				const endAt = DateTime.fromJSDate(booking.endDate)
 					.plus({ days: 1 })
 					.startOf("day");

--- a/src/services/cabins/service.ts
+++ b/src/services/cabins/service.ts
@@ -242,31 +242,24 @@ export class CabinService implements ICabinService {
 		},
 		InvalidArugmentErrorType | InternalServerError
 	> {
-		const bookingSemesters = await this.getBookingSemesters();
-		if (!bookingSemesters.ok) {
-			return bookingSemesters;
-		}
 		const cabins = await Promise.all(
 			params.cabins.map((cabin) => this.cabinRepository.getCabinById(cabin.id)),
 		);
 
-		const occupiedDateIntervalsResult = await this.getOccupiedDateIntervals(
+		const getValidBookingIntervalsResult = await this.getValidBookingIntervals(
 			ctx,
-			{ cabins },
+			{
+				cabins,
+				minimumBookingDurationDays: 2,
+			},
 		);
-		const bookableDateIntervalsResult = this.getBookableDateIntervals(ctx, {
-			bookingSemesters: bookingSemesters.data.semesters,
-		});
-		if (!occupiedDateIntervalsResult.ok) {
-			return occupiedDateIntervalsResult;
+		if (!getValidBookingIntervalsResult.ok) {
+			return getValidBookingIntervalsResult;
 		}
-		if (!bookableDateIntervalsResult.ok) {
-			return bookableDateIntervalsResult;
-		}
+		const { validBookingIntervals } = getValidBookingIntervalsResult.data;
 
 		const validateResult = this.validateBooking(ctx, {
-			bookableDateIntervals: bookableDateIntervalsResult.data.intervals,
-			occupiedDateIntervals: occupiedDateIntervalsResult.data.intervals,
+			validBookingIntervals,
 			cabins,
 			data: params,
 		});
@@ -369,8 +362,7 @@ export class CabinService implements ICabinService {
 		ctx: Context,
 		params: {
 			data: NewBookingParams;
-			bookableDateIntervals: Interval[];
-			occupiedDateIntervals: Interval[];
+			validBookingIntervals: Interval[];
 			cabins: Cabin[];
 		},
 	): TResult<
@@ -382,7 +374,7 @@ export class CabinService implements ICabinService {
 		},
 		InvalidArugmentErrorType
 	> {
-		const { bookableDateIntervals, occupiedDateIntervals } = params;
+		const { validBookingIntervals } = params;
 
 		const bookingSchema = z
 			.object({
@@ -390,10 +382,16 @@ export class CabinService implements ICabinService {
 				lastName: z.string().min(1, "last name must be at least 1 character"),
 				startDate: z
 					.date()
-					.min(new Date(), { message: "start date must be in the future" }),
+					.min(new Date(), { message: "start date must be in the future" })
+					.transform((date) =>
+						DateTime.fromJSDate(date).startOf("day").toJSDate(),
+					),
 				endDate: z
 					.date()
-					.min(new Date(), { message: "end date must be in the future" }),
+					.min(new Date(), { message: "end date must be in the future" })
+					.transform((date) =>
+						DateTime.fromJSDate(date).endOf("day").toJSDate(),
+					),
 				email: z.string().email({ message: "invalid email" }),
 				phoneNumber: z.string().regex(/^(0047|\+47|47)?\d{8}$/, {
 					message: "invalid phone number",
@@ -418,7 +416,11 @@ export class CabinService implements ICabinService {
 				(obj) => {
 					const checkIn = DateTime.fromJSDate(obj.startDate);
 					const checkOut = DateTime.fromJSDate(obj.endDate);
-					return this.isBookingMinimumLength(ctx, { checkIn, checkOut });
+					const interval = Interval.fromDateTimes(checkIn, checkOut);
+					return this.isIntervalGteMinimumDays(ctx, {
+						interval,
+						minimumBookingDurationDays: 2,
+					});
 				},
 				{
 					message: "the booking must be at least 1 day long",
@@ -427,10 +429,9 @@ export class CabinService implements ICabinService {
 			)
 			.refine(
 				(booking) => {
-					const isAvailableForCheckIn = this.isAvailableForCheckIn(ctx, {
-						bookableDateIntervals,
-						occupiedDateIntervals,
+					const isAvailableForCheckIn = this.isDateBookable(ctx, {
 						date: DateTime.fromJSDate(booking.startDate),
+						validBookingIntervals,
 					});
 					return isAvailableForCheckIn;
 				},
@@ -441,9 +442,8 @@ export class CabinService implements ICabinService {
 			)
 			.refine(
 				(booking) => {
-					const isAvailableForCheckOut = this.isAvailableForCheckOut(ctx, {
-						bookableDateIntervals,
-						occupiedDateIntervals,
+					const isAvailableForCheckOut = this.isDateBookable(ctx, {
+						validBookingIntervals,
 						date: DateTime.fromJSDate(booking.endDate),
 					});
 					return isAvailableForCheckOut;
@@ -460,8 +460,7 @@ export class CabinService implements ICabinService {
 					const isBookingIntervalAvailable = this.isBookingIntervalAvailable(
 						ctx,
 						{
-							bookableDateIntervals,
-							occupiedDateIntervals,
+							validBookingIntervals,
 							checkIn,
 							checkOut,
 						},
@@ -562,28 +561,18 @@ export class CabinService implements ICabinService {
 			}
 			const { booking } = getBookingResult.data;
 
-			const getOccupiedDateIntervalsResult =
-				await this.getOccupiedDateIntervals(ctx, { cabins: booking.cabins });
-			if (!getOccupiedDateIntervalsResult.ok) {
-				return getOccupiedDateIntervalsResult;
+			const getValidBookingIntervalsResult =
+				await this.getValidBookingIntervals(ctx, {
+					cabins: booking.cabins,
+					minimumBookingDurationDays: 2,
+				});
+			if (!getValidBookingIntervalsResult.ok) {
+				return getValidBookingIntervalsResult;
 			}
-			const getBookingSemestersResult = await this.getBookingSemesters();
-			if (!getBookingSemestersResult.ok) {
-				return getBookingSemestersResult;
-			}
-			const getBookableDateIntervalsResult = this.getBookableDateIntervals(
-				ctx,
-				{
-					bookingSemesters: getBookingSemestersResult.data.semesters,
-				},
-			);
-			if (!getBookableDateIntervalsResult.ok) {
-				return getBookableDateIntervalsResult;
-			}
+			const { validBookingIntervals } = getValidBookingIntervalsResult.data;
 
 			const isAvailableForBooking = this.isBookingIntervalAvailable(ctx, {
-				bookableDateIntervals: getBookableDateIntervalsResult.data.intervals,
-				occupiedDateIntervals: getOccupiedDateIntervalsResult.data.intervals,
+				validBookingIntervals,
 				checkIn: DateTime.fromJSDate(booking.startDate),
 				checkOut: DateTime.fromJSDate(booking.endDate),
 			});
@@ -647,11 +636,23 @@ export class CabinService implements ICabinService {
 			startAt: z
 				.date()
 				.nullish()
-				.transform((val) => val ?? undefined),
+				.transform((val) => val ?? undefined)
+				.transform((val) => {
+					if (val) {
+						return DateTime.fromJSDate(val).startOf("day").toJSDate();
+					}
+					return val;
+				}),
 			endAt: z
 				.date()
 				.nullish()
-				.transform((val) => val ?? undefined),
+				.transform((val) => val ?? undefined)
+				.transform((val) => {
+					if (val) {
+						return DateTime.fromJSDate(val).endOf("day").toJSDate();
+					}
+					return val;
+				}),
 			bookingsEnabled: z
 				.boolean()
 				.nullish()
@@ -693,18 +694,28 @@ export class CabinService implements ICabinService {
 		try {
 			const schema = z.object({
 				semester: z.nativeEnum(Semester),
-				startAt: z.date().default(
-					DateTime.fromObject({
-						month: data.semester === "SPRING" ? 1 : 8,
-						day: 1,
-					}).toJSDate(),
-				),
-				endAt: z.date().default(
-					DateTime.fromObject({
-						month: data.semester === "SPRING" ? 7 : 12,
-						day: 31,
-					}).toJSDate(),
-				),
+				startAt: z
+					.date()
+					.default(
+						DateTime.fromObject({
+							month: data.semester === "SPRING" ? 1 : 8,
+							day: 1,
+						}).toJSDate(),
+					)
+					.transform((date) =>
+						DateTime.fromJSDate(date).startOf("day").toJSDate(),
+					),
+				endAt: z
+					.date()
+					.default(
+						DateTime.fromObject({
+							month: data.semester === "SPRING" ? 7 : 12,
+							day: 31,
+						}).toJSDate(),
+					)
+					.transform((date) =>
+						DateTime.fromJSDate(date).endOf("day").toJSDate(),
+					),
 				bookingsEnabled: z.boolean().default(false),
 			});
 
@@ -750,16 +761,15 @@ export class CabinService implements ICabinService {
 		}
 	}
 
-	private isBookingMinimumLength(
+	private isIntervalGteMinimumDays(
 		_ctx: Context,
 		params: {
-			checkIn: DateTime;
-			checkOut: DateTime;
-			minimumDays?: number;
+			interval: Interval;
+			minimumBookingDurationDays: number;
 		},
 	): boolean {
-		const { checkIn, checkOut, minimumDays = 1 } = params;
-		return minimumDays <= checkOut.diff(checkIn, "days").as("days");
+		const { interval, minimumBookingDurationDays } = params;
+		return interval.count("days") >= minimumBookingDurationDays;
 	}
 
 	/**
@@ -928,24 +938,19 @@ export class CabinService implements ICabinService {
 		const cabins = await Promise.all(
 			params.cabins.map((cabin) => this.cabinRepository.getCabinById(cabin.id)),
 		);
-		const getOccupiedDateIntervalsResult = await this.getOccupiedDateIntervals(
-			ctx,
-			{ cabins },
-		);
-		if (!getOccupiedDateIntervalsResult.ok) {
-			return getOccupiedDateIntervalsResult;
-		}
-		const getBookingSemestersResult = await this.getBookingSemesters();
-		if (!getBookingSemestersResult.ok) {
-			return getBookingSemestersResult;
-		}
 
-		const getBookableDateIntervalsResult = this.getBookableDateIntervals(ctx, {
-			bookingSemesters: getBookingSemestersResult.data.semesters,
-		});
-		if (!getBookableDateIntervalsResult.ok) {
-			return getBookableDateIntervalsResult;
+		const getValidBookingIntervalsResult = await this.getValidBookingIntervals(
+			ctx,
+			{
+				cabins,
+				minimumBookingDurationDays: 2,
+			},
+		);
+		if (!getValidBookingIntervalsResult.ok) {
+			return getValidBookingIntervalsResult;
 		}
+		const { validBookingIntervals, occupiedDateIntervals } =
+			getValidBookingIntervalsResult.data;
 
 		const getCalendarMonthsResult = this.getCalendarMonths(ctx, params);
 		if (!getCalendarMonthsResult.ok) {
@@ -956,8 +961,8 @@ export class CabinService implements ICabinService {
 		for (const calendarMonth of calendarMonths) {
 			const getAvailabilityForMonthResult = this.getAvailabilityForMonth(ctx, {
 				calendarMonth,
-				bookableDateIntervals: getBookableDateIntervalsResult.data.intervals,
-				occupiedDateIntervals: getOccupiedDateIntervalsResult.data.intervals,
+				validBookingIntervals,
+				occupiedDateIntervals,
 				cabins,
 				guests: params.guests,
 			});
@@ -975,56 +980,61 @@ export class CabinService implements ICabinService {
 		return params.guests.internal >= params.guests.external;
 	}
 
-	private isAvailableForCheckIn(
+	private isOnlyAvailableForCheckIn(
 		_ctx: Context,
 		params: {
 			date: DateTime;
-			occupiedDateIntervals: Interval[];
-			bookableDateIntervals: Interval[];
+			validBookingIntervals: Interval[];
 		},
 	): boolean {
-		const { date, occupiedDateIntervals, bookableDateIntervals } = params;
-		const minimumCheckInInterval = Interval.fromDateTimes(
-			date.startOf("day"),
-			date.plus({ days: 1 }).endOf("day"),
-		);
+		const { date, validBookingIntervals } = params;
 
-		const isAvailableForCheckIn =
-			occupiedDateIntervals.every(
-				(interval) => !interval.overlaps(minimumCheckInInterval),
-			) &&
-			bookableDateIntervals.some((interval) =>
-				interval.engulfs(minimumCheckInInterval),
-			);
+		const isAvailableForCheckIn = validBookingIntervals.some((interval) => {
+			const { start } = interval;
+			if (!start) return false;
+			// Luxon intervals are half-open, so the result of running difference on intervals is that the
+			// end date of the interval is exactly the start time of the unavailable day.
+			return +start === +date;
+		});
+		if (date.day === 1 && date.month === 1) {
+			_ctx.log.info({
+				date,
+				isAvailableForCheckIn,
+				validBookingIntervals,
+			});
+		}
+		if (date.day === 7 && date.month === 1) {
+			_ctx.log.info({
+				date,
+				isAvailableForCheckIn,
+				validBookingIntervals,
+			});
+		}
 		return isAvailableForCheckIn;
 	}
 
 	/**
-	 * isAvailableForCheckOut returns true if the given date is available for check-out, otherwise false.
+	 * isOnlyAvailableForCheckOut returns true if the given date is available for check-out, otherwise false.
 	 *
 	 * Being available for check out means that the date is preceded by at least one day where bookings are enabled,
 	 * and the date is not occupied by any other booking.
 	 */
-	private isAvailableForCheckOut(
+	private isOnlyAvailableForCheckOut(
 		_ctx: Context,
 		params: {
 			date: DateTime;
-			occupiedDateIntervals: Interval[];
-			bookableDateIntervals: Interval[];
+			validBookingIntervals: Interval[];
 		},
 	): boolean {
-		const { date } = params;
-		const minimumCheckOutInterval = Interval.fromDateTimes(
-			date.minus({ days: 1 }).startOf("day"),
-			date.endOf("day"),
-		);
-		const isAvailableForCheckOut =
-			params.occupiedDateIntervals.every(
-				(interval) => !interval.overlaps(minimumCheckOutInterval),
-			) &&
-			params.bookableDateIntervals.some((interval) =>
-				interval.engulfs(minimumCheckOutInterval),
-			);
+		const { date, validBookingIntervals } = params;
+		const nextDay = date.plus({ days: 1 }).startOf("day");
+		const isAvailableForCheckOut = validBookingIntervals.some((interval) => {
+			const { end } = interval;
+			if (!end) return false;
+			// Luxon intervals are half-open, so the result of running difference on intervals is that the
+			// end date of the interval is exactly the start time of the unavailable day.
+			return +end === +nextDay;
+		});
 		return isAvailableForCheckOut;
 	}
 
@@ -1033,14 +1043,11 @@ export class CabinService implements ICabinService {
 	 */
 	private isDateBookable(
 		_ctx: Context,
-		params: { date: DateTime; bookableDateIntervals: Interval[] },
+		params: { date: DateTime; validBookingIntervals: Interval[] },
 	): boolean {
-		const { date, bookableDateIntervals } = params;
-		const isFutureDate = date >= DateTime.now().startOf("day");
-		return (
-			isFutureDate &&
-			bookableDateIntervals.some((interval) => interval.contains(date))
-		);
+		const { date, validBookingIntervals } = params;
+		if (date < DateTime.now().startOf("day")) return false;
+		return validBookingIntervals.some((interval) => interval.contains(date));
 	}
 
 	/**
@@ -1059,30 +1066,23 @@ export class CabinService implements ICabinService {
 		params: {
 			checkIn: DateTime;
 			checkOut: DateTime;
-			occupiedDateIntervals: Interval[];
-			bookableDateIntervals: Interval[];
+			validBookingIntervals: Interval[];
 		},
 	): boolean {
-		const { checkIn, checkOut, occupiedDateIntervals, bookableDateIntervals } =
-			params;
+		const { checkIn, checkOut, validBookingIntervals } = params;
 		const bookingInterval = Interval.fromDateTimes(checkIn, checkOut);
 		// the interval has to be available for the entire duration, there can be no overlap with occupied intervals
-		const isOccupied = occupiedDateIntervals.some((interval) =>
-			interval.overlaps(bookingInterval),
-		);
-		// the interval has to be engulfed by bookable intervals
-		const isBookable = bookableDateIntervals.some((interval) =>
+		return validBookingIntervals.some((interval) =>
 			interval.engulfs(bookingInterval),
 		);
-		return isBookable && !isOccupied;
 	}
 
 	private getAvailabilityForMonth(
 		ctx: Context,
 		params: {
 			calendarMonth: CalendarMonth;
+			validBookingIntervals: Interval[];
 			occupiedDateIntervals: Interval[];
-			bookableDateIntervals: Interval[];
 			guests: {
 				internal: number;
 				external: number;
@@ -1092,29 +1092,24 @@ export class CabinService implements ICabinService {
 	): TResult<{ calendarMonth: CalendarMonth }, InternalServerError> {
 		const {
 			calendarMonth,
+			validBookingIntervals,
 			occupiedDateIntervals,
-			bookableDateIntervals,
 			guests,
 		} = params;
 		for (const calendarDay of calendarMonth.days) {
 			const isBookable = this.isDateBookable(ctx, {
 				date: calendarDay.calendarDate,
-				bookableDateIntervals,
-			});
-			const isAvailable = this.isDateAvailable(ctx, {
-				date: calendarDay.calendarDate,
-				occupiedDateIntervals,
+				validBookingIntervals: validBookingIntervals,
 			});
 
-			const availableForCheckIn = this.isAvailableForCheckIn(ctx, {
+			const availableForCheckIn = this.isOnlyAvailableForCheckIn(ctx, {
 				date: calendarDay.calendarDate,
-				occupiedDateIntervals,
-				bookableDateIntervals,
+				validBookingIntervals,
 			});
-			const availableForCheckOut = this.isAvailableForCheckOut(ctx, {
+
+			const availableForCheckOut = this.isOnlyAvailableForCheckOut(ctx, {
 				date: calendarDay.calendarDate,
-				occupiedDateIntervals,
-				bookableDateIntervals,
+				validBookingIntervals,
 			});
 			const price = this.getPrice(ctx, {
 				date: calendarDay.calendarDate,
@@ -1126,7 +1121,10 @@ export class CabinService implements ICabinService {
 			}
 
 			calendarDay.price = price.data.price;
-			calendarDay.available = isAvailable;
+			calendarDay.available = this.isDateAvailable(ctx, {
+				date: calendarDay.calendarDate,
+				occupiedDateIntervals,
+			});
 			calendarDay.bookable = isBookable;
 			calendarDay.availableForCheckIn = availableForCheckIn;
 			calendarDay.availableForCheckOut = availableForCheckOut;
@@ -1135,6 +1133,94 @@ export class CabinService implements ICabinService {
 			ok: true,
 			data: { calendarMonth: calendarMonth },
 		};
+	}
+
+	/**
+	 * getValidBookingIntervals returns a list of intervals where bookings are allowed, i.e.
+	 * intervals where there are bookable dates and no occupied dates. The intervals are half-open,
+	 * meaning that the end date of the interval is the start date of the next interval. Thus,
+	 * the interval [start, end) is the same as the interval [start, end-1]. As a result,
+	 * the intervals that are derived from bookings, booking semesters, etc. are all adjusted
+	 * to have their end date be the start date of the next day. This is to make it easier to
+	 * find the valid intervals.
+	 */
+	private async getValidBookingIntervals(
+		ctx: Context,
+		params: {
+			cabins: { id: string }[];
+			minimumBookingDurationDays: number;
+		},
+	): ResultAsync<
+		{ validBookingIntervals: Interval[]; occupiedDateIntervals: Interval[] },
+		InternalServerError
+	> {
+		const { cabins, minimumBookingDurationDays } = params;
+		const occupiedDateIntervalsResult = await this.getOccupiedDateIntervals(
+			ctx,
+			{ cabins },
+		);
+		const bookingSemesters = await this.getBookingSemesters();
+		if (!bookingSemesters.ok) {
+			return bookingSemesters;
+		}
+		const bookableDateIntervalsResult = this.getBookableDateIntervals(ctx, {
+			bookingSemesters: bookingSemesters.data.semesters,
+		});
+		if (!occupiedDateIntervalsResult.ok) {
+			return occupiedDateIntervalsResult;
+		}
+		if (!bookableDateIntervalsResult.ok) {
+			return bookableDateIntervalsResult;
+		}
+		const { validBookingIntervals } = this.createValidBookingIntervals(ctx, {
+			occupiedDateIntervals: occupiedDateIntervalsResult.data.intervals,
+			bookableDateIntervals: bookableDateIntervalsResult.data.intervals,
+			minimumBookingDurationDays,
+		});
+		return {
+			ok: true,
+			data: {
+				validBookingIntervals,
+				occupiedDateIntervals: occupiedDateIntervalsResult.data.intervals,
+			},
+		};
+	}
+
+	/**
+	 * A valid booking interval is any interval which is at least minimumBookingDuration long, is engulfed by a bookable date interval, and does not overlap with any occupied date intervals.
+	 */
+	private createValidBookingIntervals(
+		ctx: Context,
+		params: {
+			occupiedDateIntervals: Interval[];
+			bookableDateIntervals: Interval[];
+			minimumBookingDurationDays: number;
+		},
+	): { validBookingIntervals: Interval[] } {
+		const {
+			occupiedDateIntervals,
+			bookableDateIntervals,
+			minimumBookingDurationDays,
+		} = params;
+		const validBookingIntervals: Interval[] = [];
+		for (const bookableDateInterval of bookableDateIntervals) {
+			const potentiallyValidBookingIntervals = bookableDateInterval.difference(
+				...occupiedDateIntervals,
+			);
+			for (const potentiallyValidBookingInterval of potentiallyValidBookingIntervals) {
+				if (
+					potentiallyValidBookingInterval.isValid &&
+					this.isIntervalGteMinimumDays(ctx, {
+						interval: potentiallyValidBookingInterval,
+						minimumBookingDurationDays,
+					})
+				) {
+					validBookingIntervals.push(potentiallyValidBookingInterval);
+				}
+			}
+		}
+
+		return { validBookingIntervals };
 	}
 
 	/**
@@ -1195,20 +1281,19 @@ export class CabinService implements ICabinService {
 
 		for (const bookingSemester of bookingSemesters) {
 			if (bookingSemester.bookingsEnabled) {
-				const startAt = DateTime.fromJSDate(bookingSemester.startAt).startOf(
-					"day",
+				const now = DateTime.now().startOf("day");
+				const startAt = DateTime.max(
+					DateTime.fromJSDate(bookingSemester.startAt).startOf("day"),
+					now,
 				);
-				const endAt = DateTime.fromJSDate(bookingSemester.endAt).endOf("day");
+				const endAt = DateTime.fromJSDate(bookingSemester.endAt)
+					.plus({ days: 1 })
+					.startOf("day");
 				const interval = Interval.fromDateTimes(startAt, endAt);
-				if (!interval.isValid) {
-					return {
-						ok: false,
-						error: new InternalServerError(
-							`Invalid booking semester interval: ${interval.invalidReason}`,
-						),
-					};
+				// Invalid intervals can occur if endAt < now
+				if (interval.isValid) {
+					intervals.push(interval);
 				}
-				intervals.push(interval);
 			}
 		}
 
@@ -1239,7 +1324,9 @@ export class CabinService implements ICabinService {
 			}
 			for (const booking of bookings.data.bookings) {
 				const startAt = DateTime.fromJSDate(booking.startDate).startOf("day");
-				const endAt = DateTime.fromJSDate(booking.endDate).endOf("day");
+				const endAt = DateTime.fromJSDate(booking.endDate)
+					.plus({ days: 1 })
+					.startOf("day");
 				intervals.push(Interval.fromDateTimes(startAt, endAt));
 			}
 		}


### PR DESCRIPTION
### Changes
- Derive `validBookingIntervals` from occupied and bookable intervals. Occupied and bookable dates are offset by 1 day to account for the fact that intervals are half-open, i.e. `[start, end)`.
- Add regression tests for days that are squeezed in-between other bookings or booking semesters, and thus are not actually bookable. 
- Make certain correctness rules less strict for Biome.