### PR TITLE
:sparkles: feat(cabins): add create cabin to schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -126,6 +126,19 @@ type CalendarMonth {
   year: Int!
 }
 
+input CreateCabinInput {
+  capacity: Int!
+  externalPrice: Int!
+  externalPriceWeekend: Int!
+  internalPrice: Int!
+  internalPriceWeekend: Int!
+  name: String!
+}
+
+type CreateCabinResponse {
+  cabin: Cabin!
+}
+
 input CreateEventCategoryInput {
   name: String!
 }
@@ -617,6 +630,11 @@ type Merchant {
 type Mutation {
   """Add a member to the organization"""
   addMember(data: AddMemberInput!): AddMemberResponse!
+
+  """
+  Create cabin, requires that the user is in an organization with the CABIN_ADMIN permission.
+  """
+  createCabin(data: CreateCabinInput!): CreateCabinResponse!
 
   """
   Create an event, requires that the user is logged in, and is a member of the organization that is hosting the event

--- a/src/graphql/cabins/resolvers/CreateCabinResponse.ts
+++ b/src/graphql/cabins/resolvers/CreateCabinResponse.ts
@@ -1,0 +1,4 @@
+import type { CreateCabinResponseResolvers } from "./../../types.generated.js";
+export const CreateCabinResponse: CreateCabinResponseResolvers = {
+	/* Implement CreateCabinResponse resolver logic here */
+};

--- a/src/graphql/cabins/resolvers/Mutation/createCabin.ts
+++ b/src/graphql/cabins/resolvers/Mutation/createCabin.ts
@@ -1,0 +1,11 @@
+import type { MutationResolvers } from "./../../../types.generated.js";
+export const createCabin: NonNullable<MutationResolvers["createCabin"]> =
+	async (_parent, { data }, ctx) => {
+		const createCabinResult = await ctx.cabins.createCabin(ctx, data);
+
+		if (!createCabinResult.ok) throw createCabinResult.error;
+
+		return {
+			cabin: createCabinResult.data.cabin,
+		};
+	};

--- a/src/graphql/cabins/resolvers/Mutation/createCabin.unit.test.ts
+++ b/src/graphql/cabins/resolvers/Mutation/createCabin.unit.test.ts
@@ -1,0 +1,99 @@
+import { faker } from "@faker-js/faker";
+import type { Cabin } from "@prisma/client";
+import { InvalidArgumentErrorV2 } from "~/domain/errors.js";
+import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "~/graphql/test-clients/unit/gql.js";
+import { Result } from "~/lib/result.js";
+
+describe("Cabin Mutations", () => {
+	describe("#createCabin", () => {
+		it("throws if an error is returned", async () => {
+			const { client, cabinService } = createMockApolloServer();
+
+			cabinService.createCabin.mockResolvedValueOnce(
+				Result.error(
+					new InvalidArgumentErrorV2("invalid argument", {
+						reason: {
+							name: ["required"],
+						},
+					}),
+				),
+			);
+			const { errors } = await client.mutate({
+				mutation: graphql(`
+                    mutation createCabin($data: CreateCabinInput!) {
+                        createCabin(data: $data) {
+                            cabin {
+                                id
+                            }
+                        }
+                    }
+                `),
+				variables: {
+					data: {
+						name: "test",
+						capacity: 10,
+						internalPrice: 100,
+						externalPrice: 200,
+						internalPriceWeekend: 150,
+						externalPriceWeekend: 250,
+					},
+				},
+			});
+
+			expect(errors).toBeDefined();
+			expect(errors).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						message: "invalid argument",
+						extensions: expect.objectContaining({
+							reason: { name: ["required"] },
+						}),
+					}),
+				]),
+			);
+		});
+
+		it("creates a cabin", async () => {
+			const { client, cabinService } = createMockApolloServer();
+
+			cabinService.createCabin.mockResolvedValueOnce(
+				Result.success({
+					cabin: {
+						id: faker.string.uuid(),
+					} as Cabin,
+				}),
+			);
+			const { errors, data } = await client.mutate({
+				mutation: graphql(`
+                    mutation createCabin($data: CreateCabinInput!) {
+                        createCabin(data: $data) {
+                            cabin {
+                                id
+                            }
+                        }
+                    }
+                `),
+				variables: {
+					data: {
+						name: "test",
+						capacity: 10,
+						internalPrice: 100,
+						externalPrice: 200,
+						internalPriceWeekend: 150,
+						externalPriceWeekend: 250,
+					},
+				},
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data).toEqual({
+				createCabin: {
+					cabin: {
+						id: expect.any(String),
+					},
+				},
+			});
+		});
+	});
+});

--- a/src/graphql/cabins/resolvers/Mutation/updateCabin.unit.test.ts
+++ b/src/graphql/cabins/resolvers/Mutation/updateCabin.unit.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import type { Cabin } from "@prisma/client";
-import { newInvalidArgumentError } from "~/domain/errors.js";
+import { InvalidArgumentErrorV2 } from "~/domain/errors.js";
 import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
 import { graphql } from "~/graphql/test-clients/unit/gql.js";
 
@@ -50,7 +50,7 @@ describe("Cabin Mutations", () => {
 
 			cabinService.updateCabin.mockResolvedValue({
 				ok: false,
-				error: newInvalidArgumentError({ message: "" }),
+				error: new InvalidArgumentErrorV2(""),
 			});
 
 			const { errors } = await client.mutate({

--- a/src/graphql/cabins/schema.graphql
+++ b/src/graphql/cabins/schema.graphql
@@ -32,6 +32,23 @@ type Mutation {
   Updates the cabin with the given ID, requires that the user is in an organization with the CABIN_ADMIN permission.
   """
   updateCabin(data: UpdateCabinInput!): UpdateCabinResponse!
+  """
+  Create cabin, requires that the user is in an organization with the CABIN_ADMIN permission.
+  """
+  createCabin(data: CreateCabinInput!): CreateCabinResponse!
+}
+
+input CreateCabinInput {
+  name: String!
+  internalPrice: Int!
+  externalPrice: Int!
+  internalPriceWeekend: Int!
+  externalPriceWeekend: Int!
+  capacity: Int!
+}
+
+type CreateCabinResponse {
+  cabin: Cabin!
 }
 
 input UpdateCabinInput {

--- a/src/lib/apollo-server.ts
+++ b/src/lib/apollo-server.ts
@@ -5,6 +5,7 @@ import { GraphQLError, type GraphQLFormattedError } from "graphql";
 import { merge } from "lodash-es";
 import {
 	InvalidArgumentError,
+	InvalidArgumentErrorV2,
 	errorCodes,
 	isUserFacingError,
 } from "~/domain/errors.js";
@@ -38,6 +39,19 @@ export function getFormatErrorHandler(log?: Partial<FastifyInstance["log"]>) {
 						reason: originalError.reason,
 					},
 				});
+			}
+			if (originalError instanceof InvalidArgumentErrorV2) {
+				return merge<GraphQLFormattedError, Partial<GraphQLFormattedError>>(
+					formattedError,
+					{
+						message: originalError.message,
+						extensions: {
+							code: originalError.code,
+							reason: originalError.reason,
+							stackTrace: originalError.getStackTrace(),
+						},
+					},
+				);
 			}
 
 			return merge({}, formattedError, {
@@ -74,6 +88,7 @@ interface ApolloContext extends Services {
 declare module "graphql" {
 	interface GraphQLErrorExtensions {
 		code: string;
+		reason?: Record<string, string[] | string | undefined>;
 	}
 }
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -29,7 +29,7 @@ import {
 	type DownstreamServiceError,
 	InternalServerError,
 	type InvalidArgumentError,
-	type InvalidArgumentErrorType,
+	type InvalidArgumentErrorV2,
 	type NotFoundError,
 	type PermissionDeniedError,
 	type UnauthorizedError,
@@ -222,7 +222,7 @@ interface ICabinService {
 		params: NewBookingParams,
 	): ResultAsync<
 		{ booking: BookingType },
-		InvalidArgumentErrorType | InternalServerError
+		InvalidArgumentErrorV2 | InternalServerError
 	>;
 	updateBookingStatus(
 		ctx: Context,
@@ -273,7 +273,7 @@ interface ICabinService {
 		},
 	): ResultAsync<
 		{ cabin: Cabin },
-		| InvalidArgumentError
+		| InvalidArgumentErrorV2
 		| PermissionDeniedError
 		| UnauthorizedError
 		| InternalServerError
@@ -331,7 +331,7 @@ interface ICabinService {
 	): ResultAsync<
 		{ cabin: Cabin },
 		| InternalServerError
-		| InvalidArgumentErrorType
+		| InvalidArgumentErrorV2
 		| UnauthorizedError
 		| PermissionDeniedError
 		| NotFoundError
@@ -811,10 +811,10 @@ async function registerServices(
 
 export { registerServices, startServer };
 export type {
+	ICabinService,
+	IFileService,
+	IOrganizationService,
+	NewBookingParams,
 	ServerDependencies,
 	Services,
-	ICabinService,
-	NewBookingParams,
-	IOrganizationService,
-	IFileService,
 };

--- a/src/services/cabins/__tests__/unit/new-booking.test.ts
+++ b/src/services/cabins/__tests__/unit/new-booking.test.ts
@@ -5,9 +5,10 @@ import { merge } from "lodash-es";
 import { DateTime } from "luxon";
 import { pino } from "pino";
 import type { BookingType } from "~/domain/cabins.js";
-import type {
-	InternalServerError,
-	InvalidArgumentError,
+import {
+	DomainErrorType,
+	type InternalServerError,
+	type InvalidArgumentError,
 } from "~/domain/errors.js";
 import { makeMockContext } from "~/lib/context.js";
 import { envToLogger } from "~/lib/fastify/logging.js";
@@ -124,7 +125,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									email: expect.any(Array),
 								}),
@@ -146,7 +147,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									phoneNumber: expect.any(Array),
 								}),
@@ -168,7 +169,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									cabins: expect.any(Array),
 								}),
@@ -190,7 +191,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									firstName: expect.any(Array),
 								}),
@@ -212,7 +213,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									lastName: expect.any(Array),
 								}),
@@ -241,7 +242,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -263,7 +264,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									endDate: expect.any(Array),
 								}),
@@ -286,7 +287,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -317,7 +318,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -344,7 +345,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.arrayContaining([
 										expect.stringContaining(
@@ -368,7 +369,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.arrayContaining([
 										expect.stringContaining(
@@ -396,7 +397,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -420,7 +421,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -446,7 +447,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -480,7 +481,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -508,7 +509,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -536,7 +537,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -570,7 +571,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -611,7 +612,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.any(Array),
 								}),
@@ -652,7 +653,7 @@ describe("CabinService", () => {
 						},
 						expected: {
 							error: expect.objectContaining({
-								name: "InvalidArgumentError",
+								type: DomainErrorType.InvalidArgumentError,
 								reason: expect.objectContaining({
 									startDate: expect.anything(),
 								}),
@@ -931,7 +932,7 @@ describe("CabinService", () => {
 			expect(newBooking).resolves.toEqual({
 				ok: false,
 				error: expect.objectContaining({
-					name: "InvalidArgumentError",
+					type: DomainErrorType.InvalidArgumentError,
 					reason: expect.objectContaining({
 						internalParticipantsCount: expect.any(Array),
 					}),
@@ -1036,7 +1037,7 @@ describe("CabinService", () => {
 			expect(newBooking).toEqual({
 				ok: false,
 				error: expect.objectContaining({
-					name: "InvalidArgumentError",
+					type: DomainErrorType.InvalidArgumentError,
 					reason: expect.objectContaining({
 						startDate: expect.arrayContaining([
 							expect.stringContaining("not available"),

--- a/src/services/cabins/__tests__/unit/update-cabin.test.ts
+++ b/src/services/cabins/__tests__/unit/update-cabin.test.ts
@@ -3,7 +3,7 @@ import type { Cabin } from "@prisma/client";
 import { mock } from "jest-mock-extended";
 import {
 	InternalServerError,
-	type InvalidArgumentErrorType,
+	type InvalidArgumentErrorV2,
 	NotFoundError,
 	PermissionDeniedError,
 	UnauthorizedError,
@@ -64,7 +64,7 @@ describe("Cabin Service", () => {
 				hasFeaturePermission: true,
 				expected: {
 					ok: false,
-					error: expect.objectContaining<Partial<InvalidArgumentErrorType>>({
+					error: expect.objectContaining<Partial<InvalidArgumentErrorV2>>({
 						code: errorCodes.ERR_BAD_USER_INPUT,
 						reason: expect.objectContaining({
 							capacity: expect.any(Array),
@@ -85,7 +85,7 @@ describe("Cabin Service", () => {
 				hasFeaturePermission: true,
 				expected: {
 					ok: false,
-					error: expect.objectContaining<Partial<InvalidArgumentErrorType>>({
+					error: expect.objectContaining<Partial<InvalidArgumentErrorV2>>({
 						code: errorCodes.ERR_BAD_USER_INPUT,
 						reason: expect.objectContaining({
 							internalPrice: expect.any(Array),
@@ -106,7 +106,7 @@ describe("Cabin Service", () => {
 				hasFeaturePermission: true,
 				expected: {
 					ok: false,
-					error: expect.objectContaining<Partial<InvalidArgumentErrorType>>({
+					error: expect.objectContaining<Partial<InvalidArgumentErrorV2>>({
 						code: errorCodes.ERR_BAD_USER_INPUT,
 						reason: expect.objectContaining({
 							name: expect.any(Array),

--- a/src/services/organizations/__tests__/unit/organizations.test.ts
+++ b/src/services/organizations/__tests__/unit/organizations.test.ts
@@ -57,7 +57,7 @@ describe("OrganizationService", () => {
 					name?: string;
 					description?: string;
 				};
-				expectedError: string;
+				expectedError: unknown;
 			}[] = [
 				{
 					name: "if the user is not a member of the organization",
@@ -69,7 +69,7 @@ describe("OrganizationService", () => {
 						organizationId: "o1",
 						name: faker.company.name(),
 					},
-					expectedError: PermissionDeniedError.name,
+					expectedError: expect.any(PermissionDeniedError),
 				},
 				{
 					name: "if the description is too long",
@@ -81,7 +81,7 @@ describe("OrganizationService", () => {
 						organizationId: "o1",
 						description: faker.string.sample(10001),
 					},
-					expectedError: InvalidArgumentError.name,
+					expectedError: expect.any(InvalidArgumentError),
 				},
 				{
 					name: "if the name is too long",
@@ -93,7 +93,7 @@ describe("OrganizationService", () => {
 						organizationId: "o1",
 						name: faker.string.sample(101),
 					},
-					expectedError: InvalidArgumentError.name,
+					expectedError: expect.any(InvalidArgumentError),
 				},
 			];
 
@@ -126,8 +126,7 @@ describe("OrganizationService", () => {
 						);
 						fail("Expected to throw");
 					} catch (err) {
-						assert(err instanceof Error);
-						expect(err.name).toBe(expectedError);
+						expect(err).toEqual(expectedError);
 					}
 				},
 			);


### PR DESCRIPTION
### Changes
- Remove the custom non-error error in favor of `InvalidArgumentErrorV2`
- Add create cabin to schema
- Add validation for `#createCabin`
- Add tests