### PR TITLE
:recycle: refactor: use inactive spans for graphql

### DIFF
--- a/src/lib/apollo-server.ts
+++ b/src/lib/apollo-server.ts
@@ -1,5 +1,5 @@
 import { unwrapResolverError } from "@apollo/server/errors";
-import type { Transaction } from "@sentry/node";
+import type { Span } from "@sentry/node";
 import type { FastifyBaseLogger, FastifyInstance } from "fastify";
 import { GraphQLError, type GraphQLFormattedError } from "graphql";
 import { merge } from "lodash-es";
@@ -68,7 +68,7 @@ export function getFormatErrorHandler(log?: Partial<FastifyInstance["log"]>) {
 interface ApolloContext extends Services {
 	user: User | null;
 	log: FastifyBaseLogger;
-	transaction?: Transaction;
+	span?: Span;
 }
 
 declare module "graphql" {

--- a/src/lib/fastify/apollo-server.ts
+++ b/src/lib/fastify/apollo-server.ts
@@ -48,7 +48,7 @@ const fastifyApolloServerPlugin: FastifyPluginAsync<{
 	) => {
 		const { services } = fastify;
 		const name = `${req.method} ${req.url}`;
-		const transaction = fastify.Sentry.startTransaction({
+		const span = fastify.Sentry.startInactiveSpan({
 			op: "apollo.graphql",
 			name,
 		});
@@ -76,7 +76,7 @@ const fastifyApolloServerPlugin: FastifyPluginAsync<{
 		return {
 			...services,
 			user,
-			transaction,
+			span,
 			log: req.log.child({ userId: user?.id, service: "apollo-server" }),
 		};
 	};

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -81,6 +81,7 @@ export const fastifyApolloSentryPlugin = (
 							// (make sure to strip out sensitive data!)
 							scope.setExtra("query", ctx.request.query);
 							scope.setExtra("variables", ctx.request.variables);
+							scope.setExtra("operationName", ctx.request.operationName);
 							if (err.path) {
 								// We can also add the path as breadcrumb
 								scope.addBreadcrumb({

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -30,7 +30,6 @@ export const fastifyApolloSentryPlugin = (
 			contextValue.log.info(
 				{
 					graphql: {
-						query: request.query,
 						variables: request.variables,
 						method: request.http?.method,
 						operationName: request.operationName,
@@ -39,12 +38,12 @@ export const fastifyApolloSentryPlugin = (
 				"incoming graphql request",
 			);
 			if (request.operationName) {
-				contextValue.transaction?.setName(request.operationName);
+				contextValue.span?.updateName(request.operationName);
 			}
 			return {
 				// biome-ignore lint/suspicious/useAwait: We need to use async/await API here.
 				async willSendResponse({ contextValue }) {
-					contextValue.transaction?.finish();
+					contextValue.span?.end();
 				},
 				async didEncounterErrors(ctx) {
 					// If we couldn't parse the operation, don't


### PR DESCRIPTION
### Changes
- Replace transactions with inactive spans, pending the 8.0 release of Sentry