### PR TITLE
✨ feat: add documents support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,9 +16,14 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  unit-test:
+  unit-test-matrix:
     name: Unit Test
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +44,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Unit Tests
-        run: pnpm run test:ci --collect-coverage
+        run: pnpm run test:ci --collect-coverage --shard ${{ matrix.shard }}/2
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v4
@@ -48,6 +53,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: coverage/unit
           flags: unittests,node
+
+  unit-test:
+    # Summary of all test shards
+    # Inspired by https://github.com/orgs/community/discussions/26822#discussioncomment-5122101
+    needs: [unit-test-matrix]
+    name: Unit Test
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check unit test results
+        # see https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#needs-context
+        # see https://stackoverflow.com/a/67532120/4907315
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}
+        run: exit 1
 
   lint:
     name: Lint

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,14 +14,25 @@ datasource db {
 
 // Documents
 model Document {
-  id        String   @id @default(uuid()) @db.Uuid
+  id          String @id @default(uuid()) @db.Uuid
   /// The display name of the document
-  name      String
-  fileId    String   @db.Uuid
+  name        String
+  description String @default("")
+  fileId      String @db.Uuid
   /// The document file
-  file      File     @relation(fields: [fileId], references: [id], onDelete: Cascade)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  file        File   @relation(fields: [fileId], references: [id], onDelete: Cascade)
+
+  categories DocumentCategory[]
+  createdAt  DateTime           @default(now())
+  updatedAt  DateTime           @updatedAt
+}
+
+model DocumentCategory {
+  id        String     @id @default(uuid()) @db.Uuid
+  name      String     @unique
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+  documents Document[]
 }
 
 // User

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,15 +12,6 @@ datasource db {
   url      = env("DATABASE_CONNECTION_STRING")
 }
 
-// Archive
-model GoogleDocument {
-  id        String   @id @default(uuid()) @db.Uuid
-  identifer String   @unique
-  favorite  Boolean  @default(false)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-}
-
 // Documents
 model Document {
   id        String   @id @default(uuid()) @db.Uuid

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,18 @@ model GoogleDocument {
   updatedAt DateTime @updatedAt
 }
 
+// Documents
+model Document {
+  id        String   @id @default(uuid()) @db.Uuid
+  /// The display name of the document
+  name      String
+  fileId    String   @db.Uuid
+  /// The document file
+  file      File     @relation(fields: [fileId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
 // User
 model User {
   id                      String        @id @default(uuid()) @db.Uuid
@@ -366,4 +378,5 @@ model File {
   userId        String?        @db.Uuid
   user          User?          @relation(fields: [userId], references: [id], onDelete: SetNull)
   organizations Organization[]
+  Document      Document[]
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -324,6 +324,14 @@ input DocumentCategoryInput {
   name: String!
 }
 
+input DocumentsCategoryInput {
+  id: ID!
+}
+
+input DocumentsInput {
+  categories: [DocumentsCategoryInput!]
+}
+
 type DocumentsResponse {
   documents: [Document!]!
   total: Int!
@@ -1098,7 +1106,7 @@ type Query {
   bookings(data: BookingsInput): BookingsResponse!
   cabins: CabinsResponse!
   categories: EventCategoriesResponse!
-  documents: DocumentsResponse!
+  documents(data: DocumentsInput): DocumentsResponse!
   event(data: EventInput!): EventResponse!
   events(data: EventsInput): EventsResponse!
   getAvailabilityCalendar(data: GetAvailabilityCalendarInput!): GetAvailabilityCalendarResponse!

--- a/schema.graphql
+++ b/schema.graphql
@@ -142,6 +142,8 @@ type CreateCabinResponse {
 }
 
 input CreateDocumentInput {
+  categories: [DocumentCategoryInput!]
+  description: String
   fileExtension: String!
   name: String!
 }
@@ -290,8 +292,14 @@ input DeleteSlotInput {
 }
 
 type Document {
+  """The categories the document is in"""
+  categories: [DocumentCategory!]!
+
   """When the document was created"""
   createdAt: DateTime!
+
+  """The description of the document"""
+  description: String!
 
   """The remote file of the document"""
   file: RemoteFile!
@@ -302,6 +310,18 @@ type Document {
 
   """When the document was last updated"""
   updatedAt: DateTime!
+}
+
+type DocumentCategory {
+  """The ID of the category"""
+  id: ID!
+
+  """The name of the category"""
+  name: String!
+}
+
+input DocumentCategoryInput {
+  name: String!
 }
 
 type DocumentsResponse {
@@ -1383,6 +1403,8 @@ input UpdateCategoriesInput {
 }
 
 input UpdateDocumentInput {
+  categories: [DocumentCategoryInput!]
+  description: String
   id: ID!
   name: String
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -141,6 +141,18 @@ type CreateCabinResponse {
   cabin: Cabin!
 }
 
+input CreateDocumentInput {
+  fileExtension: String!
+  name: String!
+}
+
+type CreateDocumentResponse {
+  document: Document!
+
+  """The URL to upload the file to, valid for 10 minutes"""
+  uploadUrl: String!
+}
+
 input CreateEventCategoryInput {
   name: String!
 }
@@ -249,6 +261,14 @@ scalar Date
 
 scalar DateTime
 
+input DeleteDocumentInput {
+  id: ID!
+}
+
+type DeleteDocumentResponse {
+  document: Document!
+}
+
 input DeleteEventCategoryInput {
   id: ID!
 }
@@ -267,6 +287,26 @@ type DeleteListingResponse {
 
 input DeleteSlotInput {
   id: ID!
+}
+
+type Document {
+  """When the document was created"""
+  createdAt: DateTime!
+
+  """The remote file of the document"""
+  file: RemoteFile!
+  id: ID!
+
+  """The display name of the document"""
+  name: String!
+
+  """When the document was last updated"""
+  updatedAt: DateTime!
+}
+
+type DocumentsResponse {
+  documents: [Document!]!
+  total: Int!
 }
 
 type Event {
@@ -637,6 +677,7 @@ type Mutation {
   Create cabin, requires that the user is in an organization with the CABIN_ADMIN permission.
   """
   createCabin(data: CreateCabinInput!): CreateCabinResponse!
+  createDocument(data: CreateDocumentInput!): CreateDocumentResponse!
 
   """
   Create an event, requires that the user is logged in, and is a member of the organization that is hosting the event
@@ -660,6 +701,7 @@ type Mutation {
   Create a new organization, and add the current user as an admin of the organization.
   """
   createOrganization(data: CreateOrganizationInput!): CreateOrganizationResponse!
+  deleteDocument(data: DeleteDocumentInput!): DeleteDocumentResponse!
 
   """Delete an event category, requires super user status"""
   deleteEventCategory(data: DeleteEventCategoryInput!): DeleteEventCategoryResponse!
@@ -707,6 +749,7 @@ type Mutation {
   Updates the cabin with the given ID, requires that the user is in an organization with the CABIN_ADMIN permission.
   """
   updateCabin(data: UpdateCabinInput!): UpdateCabinResponse!
+  updateDocument(data: UpdateDocumentInput!): UpdateDocumentResponse!
 
   """"""
   updateEvent(data: UpdateEventInput!, id: ID!): UpdateEventResponse!
@@ -1035,6 +1078,7 @@ type Query {
   bookings(data: BookingsInput): BookingsResponse!
   cabins: CabinsResponse!
   categories: EventCategoriesResponse!
+  documents: DocumentsResponse!
   event(data: EventInput!): EventResponse!
   events(data: EventsInput): EventsResponse!
   getAvailabilityCalendar(data: GetAvailabilityCalendarInput!): GetAvailabilityCalendarResponse!
@@ -1336,6 +1380,15 @@ type UpdateCabinResponse {
 
 input UpdateCategoriesInput {
   id: ID!
+}
+
+input UpdateDocumentInput {
+  id: ID!
+  name: String
+}
+
+type UpdateDocumentResponse {
+  document: Document!
 }
 
 input UpdateEventCategoryInput {

--- a/src/domain/documents.ts
+++ b/src/domain/documents.ts
@@ -8,12 +8,25 @@ import type {
 	UnauthorizedError,
 } from "./errors.js";
 
+class DocumentCategory {
+	id: string;
+	name: string;
+
+	constructor(params: { id: string; name: string }) {
+		const { id, name } = params;
+		this.id = id;
+		this.name = name;
+	}
+}
+
 class Document {
 	name: string;
 	fileId: string;
 	createdAt: Date;
 	updatedAt: Date;
 	id: string;
+	description: string;
+	categories: DocumentCategory[];
 
 	constructor(params: {
 		name: string;
@@ -21,13 +34,18 @@ class Document {
 		createdAt: Date;
 		updatedAt: Date;
 		id: string;
+		description?: string;
+		categories?: DocumentCategory[];
 	}) {
-		const { name, fileId, createdAt, updatedAt, id } = params;
+		const { name, fileId, createdAt, updatedAt, id, description, categories } =
+			params;
 		this.name = name;
 		this.fileId = fileId;
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
 		this.id = id;
+		this.description = description ?? "";
+		this.categories = categories ?? [];
 	}
 }
 
@@ -74,4 +92,4 @@ type DocumentService = {
 };
 
 export type { DocumentService };
-export { Document };
+export { Document, DocumentCategory };

--- a/src/domain/documents.ts
+++ b/src/domain/documents.ts
@@ -4,6 +4,7 @@ import type {
 	DownstreamServiceError,
 	InternalServerError,
 	InvalidArgumentErrorV2,
+	NotFoundError,
 	PermissionDeniedError,
 	UnauthorizedError,
 } from "./errors.js";
@@ -64,20 +65,26 @@ type DocumentService = {
 		>;
 		update(
 			ctx: Context,
-			data: Pick<Document, "id"> & Partial<Pick<Document, "name">>,
+			data: Pick<Document, "id"> &
+				Partial<{
+					name: string | null;
+					description: string | null;
+					categories: { name: string }[] | null;
+				}>,
 		): ResultAsync<
 			{ document: Document },
 			| InvalidArgumentErrorV2
 			| InternalServerError
 			| PermissionDeniedError
 			| UnauthorizedError
+			| NotFoundError
 		>;
 		delete(
 			ctx: Context,
 			data: Pick<Document, "id">,
 		): ResultAsync<
 			{ document: Document },
-			| InvalidArgumentErrorV2
+			| NotFoundError
 			| InternalServerError
 			| PermissionDeniedError
 			| UnauthorizedError

--- a/src/domain/documents.ts
+++ b/src/domain/documents.ts
@@ -1,0 +1,64 @@
+import type { Context } from "~/lib/context.js";
+import type { ResultAsync } from "~/lib/result.js";
+import type {
+	DownstreamServiceError,
+	InternalServerError,
+	InvalidArgumentErrorV2,
+	PermissionDeniedError,
+	UnauthorizedError,
+} from "./errors.js";
+
+class Document {
+	constructor(
+		public name: string,
+		public fileId: string,
+		public createdAt: Date,
+		public updatedAt: Date,
+		public id: string,
+	) {}
+}
+
+type DocumentService = {
+	documents: {
+		create(
+			ctx: Context,
+			data: Pick<Document, "name"> & { fileExtension: string },
+		): ResultAsync<
+			{ document: Document; uploadUrl: string },
+			| InvalidArgumentErrorV2
+			| InternalServerError
+			| PermissionDeniedError
+			| UnauthorizedError
+			| DownstreamServiceError
+		>;
+		update(
+			ctx: Context,
+			data: Pick<Document, "id"> & Partial<Pick<Document, "name">>,
+		): ResultAsync<
+			{ document: Document },
+			| InvalidArgumentErrorV2
+			| InternalServerError
+			| PermissionDeniedError
+			| UnauthorizedError
+		>;
+		delete(
+			ctx: Context,
+			data: Pick<Document, "id">,
+		): ResultAsync<
+			{ document: Document },
+			| InvalidArgumentErrorV2
+			| InternalServerError
+			| PermissionDeniedError
+			| UnauthorizedError
+		>;
+		findMany(
+			ctx: Context,
+		): ResultAsync<
+			{ documents: Document[]; total: number },
+			InternalServerError | PermissionDeniedError | UnauthorizedError
+		>;
+	};
+};
+
+export type { DocumentService };
+export { Document };

--- a/src/domain/documents.ts
+++ b/src/domain/documents.ts
@@ -84,6 +84,7 @@ type DocumentService = {
 		>;
 		findMany(
 			ctx: Context,
+			by?: { categories?: { id: string }[] | null } | null,
 		): ResultAsync<
 			{ documents: Document[]; total: number },
 			InternalServerError | PermissionDeniedError | UnauthorizedError

--- a/src/domain/documents.ts
+++ b/src/domain/documents.ts
@@ -9,13 +9,26 @@ import type {
 } from "./errors.js";
 
 class Document {
-	constructor(
-		public name: string,
-		public fileId: string,
-		public createdAt: Date,
-		public updatedAt: Date,
-		public id: string,
-	) {}
+	name: string;
+	fileId: string;
+	createdAt: Date;
+	updatedAt: Date;
+	id: string;
+
+	constructor(params: {
+		name: string;
+		fileId: string;
+		createdAt: Date;
+		updatedAt: Date;
+		id: string;
+	}) {
+		const { name, fileId, createdAt, updatedAt, id } = params;
+		this.name = name;
+		this.fileId = fileId;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+		this.id = id;
+	}
 }
 
 type DocumentService = {

--- a/src/graphql/documents/resolvers/CreateDocumentResponse.ts
+++ b/src/graphql/documents/resolvers/CreateDocumentResponse.ts
@@ -1,0 +1,4 @@
+import type { CreateDocumentResponseResolvers } from "./../../types.generated.js";
+export const CreateDocumentResponse: CreateDocumentResponseResolvers = {
+	/* Implement CreateDocumentResponse resolver logic here */
+};

--- a/src/graphql/documents/resolvers/DeleteDocumentResponse.ts
+++ b/src/graphql/documents/resolvers/DeleteDocumentResponse.ts
@@ -1,0 +1,4 @@
+import type { DeleteDocumentResponseResolvers } from "./../../types.generated.js";
+export const DeleteDocumentResponse: DeleteDocumentResponseResolvers = {
+	/* Implement DeleteDocumentResponse resolver logic here */
+};

--- a/src/graphql/documents/resolvers/Document.ts
+++ b/src/graphql/documents/resolvers/Document.ts
@@ -1,7 +1,9 @@
 import type { DocumentResolvers } from "./../../types.generated.js";
 export const Document: DocumentResolvers = {
 	/* Implement Document resolver logic here */
-	file: () => {
-		/* Document.file resolver is required because Document.file exists but DocumentMapper.file does not */
+	file: async ({ fileId }, _args, ctx) => {
+		const getFileResult = await ctx.files.getFile(ctx, { id: fileId });
+		if (!getFileResult.ok) throw getFileResult.error;
+		return getFileResult.data.file;
 	},
 };

--- a/src/graphql/documents/resolvers/Document.ts
+++ b/src/graphql/documents/resolvers/Document.ts
@@ -1,0 +1,7 @@
+import type { DocumentResolvers } from "./../../types.generated.js";
+export const Document: DocumentResolvers = {
+	/* Implement Document resolver logic here */
+	file: () => {
+		/* Document.file resolver is required because Document.file exists but DocumentMapper.file does not */
+	},
+};

--- a/src/graphql/documents/resolvers/DocumentCategory.ts
+++ b/src/graphql/documents/resolvers/DocumentCategory.ts
@@ -1,0 +1,4 @@
+import type { DocumentCategoryResolvers } from "./../../types.generated.js";
+export const DocumentCategory: DocumentCategoryResolvers = {
+	/* Implement DocumentCategory resolver logic here */
+};

--- a/src/graphql/documents/resolvers/DocumentsResponse.ts
+++ b/src/graphql/documents/resolvers/DocumentsResponse.ts
@@ -1,0 +1,4 @@
+import type { DocumentsResponseResolvers } from "./../../types.generated.js";
+export const DocumentsResponse: DocumentsResponseResolvers = {
+	/* Implement DocumentsResponse resolver logic here */
+};

--- a/src/graphql/documents/resolvers/Mutation/createDocument.ts
+++ b/src/graphql/documents/resolvers/Mutation/createDocument.ts
@@ -1,0 +1,12 @@
+import type { MutationResolvers } from "./../../../types.generated.js";
+export const createDocument: NonNullable<MutationResolvers["createDocument"]> =
+	async (_parent, { data }, ctx) => {
+		const createResult = await ctx.documents.documents.create(ctx, data);
+		if (!createResult.ok) throw createResult.error;
+
+		const { document, uploadUrl } = createResult.data;
+		return {
+			document,
+			uploadUrl,
+		};
+	};

--- a/src/graphql/documents/resolvers/Mutation/createDocument.unit.test.ts
+++ b/src/graphql/documents/resolvers/Mutation/createDocument.unit.test.ts
@@ -1,0 +1,100 @@
+import { faker } from "@faker-js/faker";
+import { Document, DocumentCategory } from "~/domain/documents.js";
+import { InternalServerError } from "~/domain/errors.js";
+import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "~/graphql/test-clients/unit/gql.js";
+import { Result } from "~/lib/result.js";
+
+describe("Document mutations", () => {
+	describe("createDocument", () => {
+		it("creates a document", async () => {
+			const { client, documents } = createMockApolloServer();
+			documents.documents.create.mockResolvedValue(
+				Result.success({
+					document: new Document({
+						id: faker.string.uuid(),
+						createdAt: new Date(),
+						fileId: faker.string.uuid(),
+						name: faker.word.adjective(),
+						updatedAt: new Date(),
+						categories: [
+							new DocumentCategory({
+								id: faker.string.uuid(),
+								name: faker.string.uuid(),
+							}),
+						],
+					}),
+					uploadUrl: faker.internet.url(),
+				}),
+			);
+
+			const { data, errors } = await client.mutate({
+				mutation: graphql(`
+                    mutation CreateDocument($data: CreateDocumentInput!) {
+                        createDocument(data: $data) {
+                            document {
+                                id
+                                categories {
+                                    id
+                                    name
+                                }
+                            }
+                        }
+                    }
+                `),
+				variables: {
+					data: {
+						name: faker.word.adjective(),
+						fileExtension: "pdf",
+					},
+				},
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data).toEqual({
+				createDocument: {
+					document: {
+						id: expect.any(String),
+						categories: [
+							{
+								id: expect.any(String),
+								name: expect.any(String),
+							},
+						],
+					},
+				},
+			});
+		});
+
+		it("throw if an error is returned", async () => {
+			const { client, documents } = createMockApolloServer();
+			documents.documents.create.mockResolvedValue(
+				Result.error(new InternalServerError("failed to create document")),
+			);
+
+			const { errors } = await client.mutate({
+				mutation: graphql(`
+                    mutation CreateDocument($data: CreateDocumentInput!) {
+                        createDocument(data: $data) {
+                            document {
+                                id
+                                categories {
+                                    id
+                                    name
+                                }
+                            }
+                        }
+                    }
+                `),
+				variables: {
+					data: {
+						name: faker.word.adjective(),
+						fileExtension: "pdf",
+					},
+				},
+			});
+
+			expect(errors).toBeDefined();
+		});
+	});
+});

--- a/src/graphql/documents/resolvers/Mutation/deleteDocument.ts
+++ b/src/graphql/documents/resolvers/Mutation/deleteDocument.ts
@@ -1,0 +1,5 @@
+import type { MutationResolvers } from "./../../../types.generated.js";
+export const deleteDocument: NonNullable<MutationResolvers["deleteDocument"]> =
+	async (_parent, _arg, _ctx) => {
+		/* Implement Mutation.deleteDocument resolver logic here */
+	};

--- a/src/graphql/documents/resolvers/Mutation/deleteDocument.ts
+++ b/src/graphql/documents/resolvers/Mutation/deleteDocument.ts
@@ -1,5 +1,6 @@
+import { InternalServerError } from "~/domain/errors.js";
 import type { MutationResolvers } from "./../../../types.generated.js";
 export const deleteDocument: NonNullable<MutationResolvers["deleteDocument"]> =
 	async (_parent, _arg, _ctx) => {
-		/* Implement Mutation.deleteDocument resolver logic here */
+		throw new InternalServerError("Not implemented");
 	};

--- a/src/graphql/documents/resolvers/Mutation/deleteDocument.ts
+++ b/src/graphql/documents/resolvers/Mutation/deleteDocument.ts
@@ -1,6 +1,8 @@
-import { InternalServerError } from "~/domain/errors.js";
 import type { MutationResolvers } from "./../../../types.generated.js";
 export const deleteDocument: NonNullable<MutationResolvers["deleteDocument"]> =
-	async (_parent, _arg, _ctx) => {
-		throw new InternalServerError("Not implemented");
+	async (_parent, { data }, ctx) => {
+		const deleteResult = await ctx.documents.documents.delete(ctx, data);
+
+		if (!deleteResult.ok) throw deleteResult.error;
+		return { document: deleteResult.data.document };
 	};

--- a/src/graphql/documents/resolvers/Mutation/deleteDocument.unit.test.ts
+++ b/src/graphql/documents/resolvers/Mutation/deleteDocument.unit.test.ts
@@ -1,0 +1,83 @@
+import { faker } from "@faker-js/faker";
+import { Document, DocumentCategory } from "~/domain/documents.js";
+import { InternalServerError } from "~/domain/errors.js";
+import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "~/graphql/test-clients/unit/gql.js";
+import { Result } from "~/lib/result.js";
+
+describe("Document mutations", () => {
+	describe("deleteDocument", () => {
+		it("deletes a document", async () => {
+			const { client, documents } = createMockApolloServer();
+			documents.documents.delete.mockResolvedValue(
+				Result.success({
+					document: new Document({
+						id: faker.string.uuid(),
+						createdAt: new Date(),
+						fileId: faker.string.uuid(),
+						name: faker.word.adjective(),
+						updatedAt: new Date(),
+						categories: [
+							new DocumentCategory({
+								id: faker.string.uuid(),
+								name: faker.string.uuid(),
+							}),
+						],
+					}),
+				}),
+			);
+
+			const { data, errors } = await client.mutate({
+				mutation: graphql(`
+                    mutation DeleteDocument($data: DeleteDocumentInput!) {
+                        deleteDocument(data: $data) {
+                            document {
+                                id
+                            }
+                        }
+                    }
+                `),
+				variables: {
+					data: {
+						id: faker.string.uuid(),
+					},
+				},
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data).toEqual({
+				deleteDocument: {
+					document: {
+						id: expect.any(String),
+					},
+				},
+			});
+		});
+
+		it("throws if an error is returned", async () => {
+			const { client, documents } = createMockApolloServer();
+			documents.documents.delete.mockResolvedValue(
+				Result.error(new InternalServerError("failed to create document")),
+			);
+
+			const { errors } = await client.mutate({
+				mutation: graphql(`
+                    mutation DeleteDocument($data: DeleteDocumentInput!) {
+                        deleteDocument(data: $data) {
+                            document {
+                                id
+                            }
+                        }
+                    }
+                `),
+				variables: {
+					data: {
+						id: faker.string.uuid(),
+					},
+				},
+			});
+
+			expect(errors).toBeDefined();
+		});
+	});
+});

--- a/src/graphql/documents/resolvers/Mutation/updateDocument.ts
+++ b/src/graphql/documents/resolvers/Mutation/updateDocument.ts
@@ -1,0 +1,5 @@
+import type { MutationResolvers } from "./../../../types.generated.js";
+export const updateDocument: NonNullable<MutationResolvers["updateDocument"]> =
+	async (_parent, _arg, _ctx) => {
+		/* Implement Mutation.updateDocument resolver logic here */
+	};

--- a/src/graphql/documents/resolvers/Mutation/updateDocument.ts
+++ b/src/graphql/documents/resolvers/Mutation/updateDocument.ts
@@ -1,5 +1,6 @@
+import { InternalServerError } from "~/domain/errors.js";
 import type { MutationResolvers } from "./../../../types.generated.js";
 export const updateDocument: NonNullable<MutationResolvers["updateDocument"]> =
 	async (_parent, _arg, _ctx) => {
-		/* Implement Mutation.updateDocument resolver logic here */
+		throw new InternalServerError("Not implemented");
 	};

--- a/src/graphql/documents/resolvers/Mutation/updateDocument.ts
+++ b/src/graphql/documents/resolvers/Mutation/updateDocument.ts
@@ -1,6 +1,8 @@
-import { InternalServerError } from "~/domain/errors.js";
 import type { MutationResolvers } from "./../../../types.generated.js";
 export const updateDocument: NonNullable<MutationResolvers["updateDocument"]> =
-	async (_parent, _arg, _ctx) => {
-		throw new InternalServerError("Not implemented");
+	async (_parent, { data }, ctx) => {
+		const updateResult = await ctx.documents.documents.update(ctx, data);
+
+		if (!updateResult.ok) throw updateResult.error;
+		return { document: updateResult.data.document };
 	};

--- a/src/graphql/documents/resolvers/Mutation/updateDocument.unit.test.ts
+++ b/src/graphql/documents/resolvers/Mutation/updateDocument.unit.test.ts
@@ -1,0 +1,83 @@
+import { faker } from "@faker-js/faker";
+import { Document, DocumentCategory } from "~/domain/documents.js";
+import { InternalServerError } from "~/domain/errors.js";
+import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "~/graphql/test-clients/unit/gql.js";
+import { Result } from "~/lib/result.js";
+
+describe("Document mutations", () => {
+	describe("updateDocument", () => {
+		it("updates a document", async () => {
+			const { client, documents } = createMockApolloServer();
+			documents.documents.update.mockResolvedValue(
+				Result.success({
+					document: new Document({
+						id: faker.string.uuid(),
+						createdAt: new Date(),
+						fileId: faker.string.uuid(),
+						name: faker.word.adjective(),
+						updatedAt: new Date(),
+						categories: [
+							new DocumentCategory({
+								id: faker.string.uuid(),
+								name: faker.string.uuid(),
+							}),
+						],
+					}),
+				}),
+			);
+
+			const { data, errors } = await client.mutate({
+				mutation: graphql(`
+                    mutation UpdateDocument($data: UpdateDocumentInput!) {
+                        updateDocument(data: $data) {
+                            document {
+                                id
+                            }
+                        }
+                    }
+                `),
+				variables: {
+					data: {
+						id: faker.string.uuid(),
+					},
+				},
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data).toEqual({
+				updateDocument: {
+					document: {
+						id: expect.any(String),
+					},
+				},
+			});
+		});
+
+		it("throws if an error is returned", async () => {
+			const { client, documents } = createMockApolloServer();
+			documents.documents.update.mockResolvedValue(
+				Result.error(new InternalServerError("failed to create document")),
+			);
+
+			const { errors } = await client.mutate({
+				mutation: graphql(`
+                    mutation UpdateDocument($data: UpdateDocumentInput!) {
+                        updateDocument(data: $data) {
+                            document {
+                                id
+                            }
+                        }
+                    }
+                `),
+				variables: {
+					data: {
+						id: faker.string.uuid(),
+					},
+				},
+			});
+
+			expect(errors).toBeDefined();
+		});
+	});
+});

--- a/src/graphql/documents/resolvers/Query/documents.ts
+++ b/src/graphql/documents/resolvers/Query/documents.ts
@@ -1,0 +1,8 @@
+import type { QueryResolvers } from "./../../../types.generated.js";
+export const documents: NonNullable<QueryResolvers["documents"]> = async (
+	_parent,
+	_arg,
+	_ctx,
+) => {
+	/* Implement Query.documents resolver logic here */
+};

--- a/src/graphql/documents/resolvers/Query/documents.ts
+++ b/src/graphql/documents/resolvers/Query/documents.ts
@@ -2,7 +2,20 @@ import type { QueryResolvers } from "./../../../types.generated.js";
 export const documents: NonNullable<QueryResolvers["documents"]> = async (
 	_parent,
 	_arg,
-	_ctx,
+	ctx,
 ) => {
-	/* Implement Query.documents resolver logic here */
+	const findManyDocumentsResult = await ctx.documents.documents.findMany(ctx);
+	if (!findManyDocumentsResult.ok) {
+		switch (findManyDocumentsResult.error.name) {
+			case "PermissionDeniedError":
+			case "UnauthorizedError":
+				return {
+					documents: [],
+					total: 0,
+				};
+			case "InternalServerError":
+				throw findManyDocumentsResult.error;
+		}
+	}
+	return findManyDocumentsResult.data;
 };

--- a/src/graphql/documents/resolvers/Query/documents.ts
+++ b/src/graphql/documents/resolvers/Query/documents.ts
@@ -1,10 +1,13 @@
 import type { QueryResolvers } from "./../../../types.generated.js";
 export const documents: NonNullable<QueryResolvers["documents"]> = async (
 	_parent,
-	_arg,
+	{ data },
 	ctx,
 ) => {
-	const findManyDocumentsResult = await ctx.documents.documents.findMany(ctx);
+	const findManyDocumentsResult = await ctx.documents.documents.findMany(
+		ctx,
+		data,
+	);
 	if (!findManyDocumentsResult.ok) {
 		switch (findManyDocumentsResult.error.name) {
 			case "PermissionDeniedError":

--- a/src/graphql/documents/resolvers/Query/documents.unit.test.ts
+++ b/src/graphql/documents/resolvers/Query/documents.unit.test.ts
@@ -1,0 +1,122 @@
+import {
+	InternalServerError,
+	PermissionDeniedError,
+	UnauthorizedError,
+} from "~/domain/errors.js";
+import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "~/graphql/test-clients/unit/gql.js";
+import { Result } from "~/lib/result.js";
+
+describe("Documents queries", () => {
+	describe("{ documents }", () => {
+		it("returns all documents and the total count", async () => {
+			const { documents, client } = createMockApolloServer();
+			documents.documents.findMany.mockResolvedValue({
+				ok: true,
+				data: {
+					documents: [],
+					total: 0,
+				},
+			});
+
+			const { data, errors } = await client.query({
+				query: graphql(`
+                    query Documents {
+                        documents {
+                            documents {
+                                id
+                            }
+                            total
+                        }
+                    }
+                `),
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data).toEqual({
+				documents: {
+					documents: [],
+					total: 0,
+				},
+			});
+		});
+
+		it("returns empty array if unauthorized", async () => {
+			const { documents, client } = createMockApolloServer();
+			documents.documents.findMany.mockResolvedValue(
+				Result.error(new UnauthorizedError("")),
+			);
+
+			const { data, errors } = await client.query({
+				query: graphql(`
+                    query Documents {
+                        documents {
+                            documents {
+                                id
+                            }
+                            total
+                        }
+                    }
+                `),
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data).toEqual({
+				documents: {
+					documents: [],
+					total: 0,
+				},
+			});
+		});
+
+		it("returns empty array on permission denied", async () => {
+			const { documents, client } = createMockApolloServer();
+			documents.documents.findMany.mockResolvedValue(
+				Result.error(new PermissionDeniedError("")),
+			);
+
+			const { data, errors } = await client.query({
+				query: graphql(`
+                    query Documents {
+                        documents {
+                            documents {
+                                id
+                            }
+                            total
+                        }
+                    }
+                `),
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data).toEqual({
+				documents: {
+					documents: [],
+					total: 0,
+				},
+			});
+		});
+
+		it("throws on internal server error", async () => {
+			const { documents, client } = createMockApolloServer();
+			documents.documents.findMany.mockResolvedValue(
+				Result.error(new InternalServerError("something went wrong")),
+			);
+
+			const { errors } = await client.query({
+				query: graphql(`
+                    query Documents {
+                        documents {
+                            documents {
+                                id
+                            }
+                            total
+                        }
+                    }
+                `),
+			});
+
+			expect(errors).toBeDefined();
+		});
+	});
+});

--- a/src/graphql/documents/resolvers/UpdateDocumentResponse.ts
+++ b/src/graphql/documents/resolvers/UpdateDocumentResponse.ts
@@ -1,0 +1,4 @@
+import type { UpdateDocumentResponseResolvers } from "./../../types.generated.js";
+export const UpdateDocumentResponse: UpdateDocumentResponseResolvers = {
+	/* Implement UpdateDocumentResponse resolver logic here */
+};

--- a/src/graphql/documents/schema.graphql
+++ b/src/graphql/documents/schema.graphql
@@ -11,11 +11,19 @@ type Mutation {
 input CreateDocumentInput {
     name: String!
     fileExtension: String!
+    description: String
+    categories: [DocumentCategoryInput!]
+}
+
+input DocumentCategoryInput {
+    name: String!
 }
 
 input UpdateDocumentInput {
     id: ID!
     name: String
+    description: String
+    categories: [DocumentCategoryInput!]
 }
 
 input DeleteDocumentInput {
@@ -63,4 +71,23 @@ type Document {
     When the document was last updated
     """
     updatedAt: DateTime!
+    """
+    The description of the document
+    """
+    description: String!
+    """
+    The categories the document is in
+    """
+    categories: [DocumentCategory!]!
+}
+
+type DocumentCategory {
+    """
+    The ID of the category
+    """
+    id: ID!
+    """
+    The name of the category
+    """
+    name: String!
 }

--- a/src/graphql/documents/schema.graphql
+++ b/src/graphql/documents/schema.graphql
@@ -1,11 +1,19 @@
 type Query {
-    documents: DocumentsResponse!
+    documents(data: DocumentsInput): DocumentsResponse!
 }
 
 type Mutation {
     createDocument(data: CreateDocumentInput!): CreateDocumentResponse!
     updateDocument(data: UpdateDocumentInput!): UpdateDocumentResponse!
     deleteDocument(data: DeleteDocumentInput!): DeleteDocumentResponse!
+}
+
+input DocumentsInput {
+    categories: [DocumentsCategoryInput!]
+}
+
+input DocumentsCategoryInput {
+    id: ID!
 }
 
 input CreateDocumentInput {

--- a/src/graphql/documents/schema.graphql
+++ b/src/graphql/documents/schema.graphql
@@ -1,0 +1,66 @@
+type Query {
+    documents: DocumentsResponse!
+}
+
+type Mutation {
+    createDocument(data: CreateDocumentInput!): CreateDocumentResponse!
+    updateDocument(data: UpdateDocumentInput!): UpdateDocumentResponse!
+    deleteDocument(data: DeleteDocumentInput!): DeleteDocumentResponse!
+}
+
+input CreateDocumentInput {
+    name: String!
+    fileExtension: String!
+}
+
+input UpdateDocumentInput {
+    id: ID!
+    name: String
+}
+
+input DeleteDocumentInput {
+    id: ID!
+}
+
+type CreateDocumentResponse {
+    document: Document!
+    """
+    The URL to upload the file to, valid for 10 minutes
+    """
+    uploadUrl: String!
+}
+
+type UpdateDocumentResponse {
+    document: Document!
+}
+
+type DeleteDocumentResponse {
+    document: Document!
+}
+
+type DocumentsResponse {
+    documents: [Document!]!
+    total: Int!
+}
+
+
+
+type Document {
+    id: ID!
+    """
+    The display name of the document
+    """
+    name: String!
+    """
+    The remote file of the document
+    """
+    file: RemoteFile!
+    """
+    When the document was created
+    """
+    createdAt: DateTime!
+    """
+    When the document was last updated
+    """
+    updatedAt: DateTime!
+}

--- a/src/graphql/documents/schema.mappers.ts
+++ b/src/graphql/documents/schema.mappers.ts
@@ -1,0 +1,1 @@
+export type { Document as DocumentMapper } from "~/domain/documents.js";

--- a/src/graphql/test-clients/mock-apollo-server.ts
+++ b/src/graphql/test-clients/mock-apollo-server.ts
@@ -86,6 +86,7 @@ export const createMockApolloServer = (logger?: Partial<FastifyBaseLogger>) => {
 	const auth = mockDeep<ApolloContext["auth"]>();
 	const products = mockDeep<ApolloContext["products"]>();
 	const files = mockDeep<ApolloContext["files"]>();
+	const documents = mockDeep<ApolloContext["documents"]>();
 
 	function createMockContext(data: CreateMockContextData = {}): ApolloContext {
 		let user: User | null = null;
@@ -103,6 +104,7 @@ export const createMockApolloServer = (logger?: Partial<FastifyBaseLogger>) => {
 			auth,
 			products,
 			files,
+			documents,
 			log: mockDeep<FastifyBaseLogger>(logger),
 		};
 
@@ -120,6 +122,7 @@ export const createMockApolloServer = (logger?: Partial<FastifyBaseLogger>) => {
 		createMockContext,
 		productService: products,
 		fileService: files,
+		documents,
 		server,
 		client,
 	};

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -51,8 +51,8 @@ import type {
 } from "~/domain/products.js";
 import type { StudyProgram, User } from "~/domain/users.js";
 import type { Context } from "~/lib/context.js";
-import { CabinRepository } from "~/repositories/cabins/repository.js";
-import { DocumentRepository } from "~/repositories/documents/repository.js";
+import { CabinRepository } from "~/repositories/cabins/index.js";
+import { DocumentRepository } from "~/repositories/documents/index.js";
 import { EventRepository } from "~/repositories/events/index.js";
 import { FileRepository } from "~/repositories/files/index.js";
 import { ListingRepository } from "~/repositories/listings/repository.js";
@@ -63,7 +63,7 @@ import { UserRepository } from "~/repositories/users/index.js";
 import { feideClient } from "~/services/auth/clients.js";
 import { AuthService } from "~/services/auth/index.js";
 import { CabinService } from "~/services/cabins/index.js";
-import { DocumentService } from "~/services/documents/service.js";
+import { DocumentService } from "~/services/documents/index.js";
 import {
 	type CreateEventParams,
 	EventService,

--- a/src/repositories/documents/documents.integration.test.ts
+++ b/src/repositories/documents/documents.integration.test.ts
@@ -6,9 +6,8 @@ import { Result } from "~/lib/result.js";
 import { buildDocuments } from "./documents.js";
 
 describe("Documents repository", () => {
+	const documents = buildDocuments({ db: prisma });
 	describe("#create", () => {
-		const documents = buildDocuments({ db: prisma });
-
 		it("creates a document", async () => {
 			const { user, file } = await makeDependencies();
 			const result = await documents.create(makeMockContext(user), {
@@ -26,21 +25,52 @@ describe("Documents repository", () => {
 			);
 		});
 	});
-});
 
-async function makeDependencies() {
-	const { files, users } = makeTestServices();
-	const user = await users.create({
-		email: faker.internet.email({ firstName: faker.string.uuid() }),
-		feideId: faker.string.uuid(),
-		firstName: faker.person.firstName(),
-		lastName: faker.person.lastName(),
-		username: faker.string.uuid(),
+	describe("#findMany", () => {
+		it("returns all documents and the total count", async () => {
+			/**
+			 * Create three documents
+			 */
+			const document1 = await makeDocument();
+			const document2 = await makeDocument();
+			const document3 = await makeDocument();
+
+			const result = await documents.findMany(makeMockContext());
+
+			if (!result.ok) throw result.error;
+
+			const { documents: actual, total } = result.data;
+			expect(total).toBeGreaterThanOrEqual(3);
+			expect(actual).toEqual(
+				expect.arrayContaining([document1, document2, document3]),
+			);
+		});
 	});
-	const createFileUploadUrlResult = await files.createFileUploadUrl(
-		makeMockContext(user),
-		{ extension: "pdf" },
-	);
-	if (!createFileUploadUrlResult.ok) throw createFileUploadUrlResult.error;
-	return { file: createFileUploadUrlResult.data.file, user };
-}
+
+	async function makeDocument() {
+		const { user, file } = await makeDependencies();
+		const result = await documents.create(makeMockContext(user), {
+			name: faker.word.adjective(),
+			fileId: file.id,
+		});
+		if (!result.ok) throw result.error;
+		return result.data.document;
+	}
+
+	async function makeDependencies() {
+		const { files, users } = makeTestServices();
+		const user = await users.create({
+			email: faker.internet.email({ firstName: faker.string.uuid() }),
+			feideId: faker.string.uuid(),
+			firstName: faker.person.firstName(),
+			lastName: faker.person.lastName(),
+			username: faker.string.uuid(),
+		});
+		const createFileUploadUrlResult = await files.createFileUploadUrl(
+			makeMockContext(user),
+			{ extension: "pdf" },
+		);
+		if (!createFileUploadUrlResult.ok) throw createFileUploadUrlResult.error;
+		return { file: createFileUploadUrlResult.data.file, user };
+	}
+});

--- a/src/repositories/documents/documents.integration.test.ts
+++ b/src/repositories/documents/documents.integration.test.ts
@@ -1,0 +1,46 @@
+import { faker } from "@faker-js/faker";
+import { makeTestServices } from "~/__tests__/dependencies-factory.js";
+import { makeMockContext } from "~/lib/context.js";
+import prisma from "~/lib/prisma.js";
+import { Result } from "~/lib/result.js";
+import { buildDocuments } from "./documents.js";
+
+describe("Documents repository", () => {
+	describe("#create", () => {
+		const documents = buildDocuments({ db: prisma });
+
+		it("creates a document", async () => {
+			const { user, file } = await makeDependencies();
+			const result = await documents.create(makeMockContext(user), {
+				name: faker.word.adjective(),
+				fileId: file.id,
+			});
+
+			expect(result).toEqual(
+				Result.success({
+					document: expect.objectContaining({
+						id: expect.any(String),
+						fileId: file.id,
+					}),
+				}),
+			);
+		});
+	});
+});
+
+async function makeDependencies() {
+	const { files, users } = makeTestServices();
+	const user = await users.create({
+		email: faker.internet.email({ firstName: faker.string.uuid() }),
+		feideId: faker.string.uuid(),
+		firstName: faker.person.firstName(),
+		lastName: faker.person.lastName(),
+		username: faker.string.uuid(),
+	});
+	const createFileUploadUrlResult = await files.createFileUploadUrl(
+		makeMockContext(user),
+		{ extension: "pdf" },
+	);
+	if (!createFileUploadUrlResult.ok) throw createFileUploadUrlResult.error;
+	return { file: createFileUploadUrlResult.data.file, user };
+}

--- a/src/repositories/documents/documents.integration.test.ts
+++ b/src/repositories/documents/documents.integration.test.ts
@@ -10,9 +10,38 @@ describe("Documents repository", () => {
 	describe("#create", () => {
 		it("creates a document", async () => {
 			const { user, file } = await makeDependencies();
+			const fields = {
+				name: faker.word.adjective(),
+				fileId: file.id,
+				description: faker.lorem.sentence(),
+			};
+			const result = await documents.create(makeMockContext(user), fields);
+
+			expect(result).toEqual(
+				Result.success({
+					document: expect.objectContaining({
+						id: expect.any(String),
+						...fields,
+					}),
+				}),
+			);
+		});
+
+		it("creates a document with categories", async () => {
+			const { user, file } = await makeDependencies();
+			const categoryName1 = faker.string.uuid();
+			const categoryName2 = faker.string.uuid();
 			const result = await documents.create(makeMockContext(user), {
 				name: faker.word.adjective(),
 				fileId: file.id,
+				categories: [
+					{
+						name: categoryName1,
+					},
+					{
+						name: categoryName2,
+					},
+				],
 			});
 
 			expect(result).toEqual(
@@ -20,6 +49,16 @@ describe("Documents repository", () => {
 					document: expect.objectContaining({
 						id: expect.any(String),
 						fileId: file.id,
+						categories: expect.arrayContaining([
+							expect.objectContaining({
+								name: categoryName1,
+								id: expect.any(String),
+							}),
+							expect.objectContaining({
+								name: categoryName2,
+								id: expect.any(String),
+							}),
+						]),
 					}),
 				}),
 			);
@@ -52,6 +91,11 @@ describe("Documents repository", () => {
 		const result = await documents.create(makeMockContext(user), {
 			name: faker.word.adjective(),
 			fileId: file.id,
+			categories: [
+				{
+					name: faker.string.uuid(),
+				},
+			],
 		});
 		if (!result.ok) throw result.error;
 		return result.data.document;

--- a/src/repositories/documents/documents.integration.test.ts
+++ b/src/repositories/documents/documents.integration.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { faker } from "@faker-js/faker";
 import { makeTestServices } from "~/__tests__/dependencies-factory.js";
+import { NotFoundError } from "~/domain/errors.js";
 import { makeMockContext } from "~/lib/context.js";
 import prisma from "~/lib/prisma.js";
 import { Result } from "~/lib/result.js";
@@ -107,6 +108,131 @@ describe("Documents repository", () => {
 			expect(total).toBe(2);
 			expect(actual).toEqual(expect.arrayContaining([document1, document2]));
 			expect(actual).not.toEqual(expect.arrayContaining([document3]));
+		});
+	});
+
+	describe("#update", () => {
+		it("updates a document", async () => {
+			const document = await makeDocument();
+			const newName = faker.word.adjective();
+
+			const result = await documents.update(makeMockContext(), {
+				id: document.id,
+				name: newName,
+			});
+
+			expect(result).toEqual(
+				Result.success({
+					document: expect.objectContaining({ name: newName }),
+				}),
+			);
+		});
+
+		it("disconnects any categories that are not in the new list", async () => {
+			const category1 = { name: faker.string.uuid() };
+			const category2 = { name: faker.string.uuid() };
+			const category3 = { name: faker.string.uuid() };
+			const document = await makeDocument({
+				categories: [category1, category2],
+			});
+
+			const newCategories = [category1, category3];
+
+			const result = await documents.update(makeMockContext(), {
+				id: document.id,
+				categories: newCategories,
+			});
+			if (!result.ok) throw result.error;
+
+			const updatedDocument = result.data.document;
+			expect(updatedDocument.categories).toEqual(
+				expect.arrayContaining([expect.objectContaining(category1)]),
+			);
+			expect(updatedDocument.categories).toEqual(
+				expect.arrayContaining([expect.objectContaining(category3)]),
+			);
+			expect(updatedDocument.categories).not.toEqual(
+				expect.arrayContaining([expect.objectContaining(category2)]),
+			);
+		});
+
+		it("leaves categories unaffected if undefined", async () => {
+			const category1 = { name: faker.string.uuid() };
+			const category2 = { name: faker.string.uuid() };
+			const document = await makeDocument({
+				categories: [category1, category2],
+			});
+
+			const result = await documents.update(makeMockContext(), {
+				id: document.id,
+				categories: undefined,
+			});
+			if (!result.ok) throw result.error;
+
+			const updatedDocument = result.data.document;
+			expect(updatedDocument.categories).toEqual(
+				expect.arrayContaining([expect.objectContaining(category1)]),
+			);
+			expect(updatedDocument.categories).toEqual(
+				expect.arrayContaining([expect.objectContaining(category2)]),
+			);
+		});
+
+		it("returns NotFoundError if the document does not exist", async () => {
+			const result = await documents.update(makeMockContext(), {
+				id: faker.string.uuid(),
+			});
+			expect(result).toEqual(Result.error(expect.any(NotFoundError)));
+		});
+
+		it("returns NotFoundError if updating categories and the document does not exist", async () => {
+			const result = await documents.update(makeMockContext(), {
+				id: faker.string.uuid(),
+				categories: [],
+			});
+			expect(result).toEqual(Result.error(expect.any(NotFoundError)));
+		});
+
+		it("returns NotFoundError if updating categories and ID is not a uuid", async () => {
+			const result = await documents.update(makeMockContext(), {
+				id: "not-a-uuid",
+				categories: [],
+			});
+			expect(result).toEqual(Result.error(expect.any(NotFoundError)));
+		});
+	});
+
+	describe("#delete", () => {
+		it("returns NotFoundError if the document does not exist", async () => {
+			const result = await documents.delete(makeMockContext(), {
+				id: faker.string.uuid(),
+			});
+			expect(result).toEqual(Result.error(expect.any(NotFoundError)));
+		});
+
+		it("returns NotFoundError id is not a UUID", async () => {
+			const result = await documents.delete(makeMockContext(), {
+				id: "not-a-uuid",
+			});
+			expect(result).toEqual(Result.error(expect.any(NotFoundError)));
+		});
+
+		it("deletes the document", async () => {
+			const document = await makeDocument();
+
+			const result = await documents.delete(makeMockContext(), {
+				id: document.id,
+			});
+			const findResult = await documents.findMany(makeMockContext());
+			if (!findResult.ok) throw findResult.error;
+			const { documents: actualDocuments } = findResult.data;
+
+			expect(actualDocuments).not.toEqual(expect.arrayContaining([document]));
+			expect(result).toEqual(
+				Result.success({
+					document: expect.objectContaining(document),
+				}),
+			);
 		});
 	});
 

--- a/src/repositories/documents/documents.ts
+++ b/src/repositories/documents/documents.ts
@@ -16,12 +16,22 @@ function buildDocuments({
 			ctx.log.info({ data }, "creating document");
 			try {
 				const document = await db.document.create({
+					include: {
+						categories: true,
+					},
 					data: {
 						name: data.name,
-						file: {
-							connect: {
-								id: data.fileId,
-							},
+						fileId: data.fileId,
+						description: data.description,
+						categories: {
+							connectOrCreate: data.categories?.map((category) => ({
+								create: {
+									name: category.name,
+								},
+								where: {
+									name: category.name,
+								},
+							})),
 						},
 					},
 				});
@@ -42,7 +52,11 @@ function buildDocuments({
 		async findMany(ctx) {
 			try {
 				ctx.log.info("finding documents");
-				const findManyPromise = db.document.findMany();
+				const findManyPromise = db.document.findMany({
+					include: {
+						categories: true,
+					},
+				});
 				const countPromise = db.document.count();
 				const [documents, total] = await Promise.all([
 					findManyPromise,

--- a/src/repositories/documents/documents.ts
+++ b/src/repositories/documents/documents.ts
@@ -1,0 +1,47 @@
+import type { PrismaClient } from "@prisma/client";
+import { InternalServerError } from "~/domain/errors.js";
+import { Result } from "~/lib/result.js";
+import type { DocumentRepositoryType } from "~/services/documents/documents.js";
+
+type DocumentDependencies = {
+	db: PrismaClient;
+};
+
+function buildDocuments({
+	db,
+}: DocumentDependencies): DocumentRepositoryType["documents"] {
+	return {
+		async create(ctx, data) {
+			ctx.log.info({ data }, "creating document");
+			try {
+				const document = await db.document.create({
+					data: {
+						name: data.name,
+						file: {
+							connect: {
+								id: data.fileId,
+							},
+						},
+					},
+				});
+				return Result.success({ document });
+			} catch (err) {
+				return Result.error(
+					new InternalServerError("failed to create document", err),
+				);
+			}
+		},
+		async delete(ctx, data) {
+			return Result.error(new InternalServerError("not implemented yet"));
+		},
+		async update(ctx, data) {
+			return Result.error(new InternalServerError("not implemented yet"));
+		},
+		async findMany(ctx) {
+			return Result.error(new InternalServerError("not implemented yet"));
+		},
+	};
+}
+
+export { buildDocuments };
+export type { DocumentDependencies };

--- a/src/repositories/documents/documents.ts
+++ b/src/repositories/documents/documents.ts
@@ -1,4 +1,5 @@
 import type { PrismaClient } from "@prisma/client";
+import { Document } from "~/domain/documents.js";
 import { InternalServerError } from "~/domain/errors.js";
 import { Result } from "~/lib/result.js";
 import type { DocumentRepositoryType } from "~/services/documents/documents.js";
@@ -24,21 +25,38 @@ function buildDocuments({
 						},
 					},
 				});
-				return Result.success({ document });
+				return Result.success({ document: new Document(document) });
 			} catch (err) {
 				return Result.error(
 					new InternalServerError("failed to create document", err),
 				);
 			}
 		},
-		async delete(ctx, data) {
+		async delete(_ctx, _data) {
 			return Result.error(new InternalServerError("not implemented yet"));
 		},
-		async update(ctx, data) {
+		async update(_ctx, _data) {
 			return Result.error(new InternalServerError("not implemented yet"));
 		},
+
 		async findMany(ctx) {
-			return Result.error(new InternalServerError("not implemented yet"));
+			try {
+				ctx.log.info("finding documents");
+				const findManyPromise = db.document.findMany();
+				const countPromise = db.document.count();
+				const [documents, total] = await Promise.all([
+					findManyPromise,
+					countPromise,
+				]);
+				return Result.success({
+					documents: documents.map((document) => new Document(document)),
+					total,
+				});
+			} catch (err) {
+				return Result.error(
+					new InternalServerError("failed to find documents", err),
+				);
+			}
 		},
 	};
 }

--- a/src/repositories/documents/index.ts
+++ b/src/repositories/documents/index.ts
@@ -1,0 +1,1 @@
+export { DocumentRepository } from "./repository.js";

--- a/src/repositories/documents/repository.ts
+++ b/src/repositories/documents/repository.ts
@@ -1,0 +1,15 @@
+import type { DocumentRepositoryType } from "~/services/documents/documents.js";
+import { type DocumentDependencies, buildDocuments } from "./documents.js";
+
+type Dependencies = DocumentDependencies;
+
+function DocumentRepository(
+	dependencies: Dependencies,
+): DocumentRepositoryType {
+	return {
+		documents: buildDocuments(dependencies),
+	};
+}
+
+export { DocumentRepository };
+export type { Dependencies };

--- a/src/repositories/documents/seed.ts
+++ b/src/repositories/documents/seed.ts
@@ -1,0 +1,130 @@
+import { faker } from "@faker-js/faker";
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+faker.seed(4913048194);
+
+const documents: Prisma.DocumentCreateInput[] = [
+	{
+		id: faker.string.uuid(),
+		name: faker.word.adjective(),
+		description: faker.lorem.sentence(),
+		categories: {
+			connectOrCreate: [
+				{
+					create: {
+						name: "Budsjett",
+					},
+					where: {
+						name: "Budsjett",
+					},
+				},
+				{
+					create: {
+						name: "2022",
+					},
+					where: {
+						name: "2022",
+					},
+				},
+			],
+		},
+		file: {
+			connectOrCreate: {
+				create: {
+					name: "file.pdf",
+				},
+				where: {
+					id: faker.string.uuid(),
+				},
+			},
+		},
+	},
+	{
+		id: faker.string.uuid(),
+		name: faker.word.adjective(),
+		description: faker.lorem.sentence(),
+		categories: {
+			connectOrCreate: [
+				{
+					create: {
+						name: "Janus:Script",
+					},
+					where: {
+						name: "Janus:Script",
+					},
+				},
+				{
+					create: {
+						name: "2024",
+					},
+					where: {
+						name: "2024",
+					},
+				},
+			],
+		},
+		file: {
+			connectOrCreate: {
+				create: {
+					name: "file.pdf",
+				},
+				where: {
+					id: faker.string.uuid(),
+				},
+			},
+		},
+	},
+	{
+		id: faker.string.uuid(),
+		name: faker.word.adjective(),
+		description: faker.lorem.sentence(),
+		categories: {
+			connectOrCreate: [
+				{
+					create: {
+						name: "Vedtekter",
+					},
+					where: {
+						name: "Vedtekter",
+					},
+				},
+				{
+					create: {
+						name: "2026",
+					},
+					where: {
+						name: "2026",
+					},
+				},
+			],
+		},
+		file: {
+			connectOrCreate: {
+				create: {
+					name: "file.pdf",
+				},
+				where: {
+					id: faker.string.uuid(),
+				},
+			},
+		},
+	},
+];
+
+async function load(db: PrismaClient) {
+	console.log("Seeding documents...");
+	for (const document of documents) {
+		await db.document.upsert({
+			where: {
+				id: document.id,
+			},
+			update: document,
+			create: document,
+		});
+	}
+
+	const documentsInDb = await db.document.findMany();
+	return { documents: documentsInDb };
+}
+
+export { load };

--- a/src/repositories/seed.ts
+++ b/src/repositories/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import * as Cabins from "./cabins/seed.js";
+import * as Documents from "./documents/seed.js";
 import * as Events from "./events/seed.js";
 import * as Listings from "./listings/seed.js";
 import * as Organizations from "./organizations/seed.js";
@@ -29,6 +30,9 @@ const main = async () => {
 	const { merchant, products } = await Products.load(db);
 	console.table(merchant);
 	console.table(products);
+
+	const { documents } = await Documents.load(db);
+	console.table(documents);
 };
 
 try {

--- a/src/services/documents/documents.ts
+++ b/src/services/documents/documents.ts
@@ -1,0 +1,224 @@
+import type { FeaturePermission } from "@prisma/client";
+import { z } from "zod";
+import type { Document, DocumentService } from "~/domain/documents.js";
+import {
+	DownstreamServiceError,
+	InternalServerError,
+	type InvalidArgumentError,
+	InvalidArgumentErrorV2,
+	PermissionDeniedError,
+	UnauthorizedError,
+} from "~/domain/errors.js";
+import type { FileType } from "~/domain/files.js";
+import type { Context } from "~/lib/context.js";
+import { Result, type ResultAsync } from "~/lib/result.js";
+
+type DocumentRepositoryType = {
+	documents: {
+		create(
+			ctx: Context,
+			data: Pick<Document, "fileId" | "name">,
+		): ResultAsync<{ document: Document }, InternalServerError>;
+		update(
+			ctx: Context,
+			data: Document,
+		): ResultAsync<
+			{ document: Document },
+			InvalidArgumentErrorV2 | InternalServerError
+		>;
+		delete(
+			ctx: Context,
+			data: Pick<Document, "id">,
+		): ResultAsync<
+			{ document: Document },
+			InvalidArgumentErrorV2 | InternalServerError
+		>;
+		findMany(
+			ctx: Context,
+		): ResultAsync<
+			{ documents: Document[]; total: number },
+			InternalServerError
+		>;
+	};
+};
+
+type PermissionService = {
+	hasFeaturePermission(
+		ctx: Context,
+		data: { featurePermission: FeaturePermission },
+	): Promise<boolean>;
+};
+
+type FileService = {
+	createFileUploadUrl(
+		ctx: Context,
+		params: { extension: string },
+	): ResultAsync<
+		{ file: FileType; url: string },
+		| DownstreamServiceError
+		| InternalServerError
+		| UnauthorizedError
+		| InvalidArgumentError
+	>;
+};
+
+type DocumentDependencies = {
+	files: FileService;
+	repository: DocumentRepositoryType;
+	permissions: PermissionService;
+};
+
+function buildDocuments({
+	repository,
+	files,
+	permissions,
+}: DocumentDependencies): DocumentService["documents"] {
+	return {
+		async create(ctx, data) {
+			if (!ctx.user)
+				return Result.error(
+					new UnauthorizedError(
+						"You must be logged in to perform this action.",
+					),
+				);
+			const hasPermission = await permissions.hasFeaturePermission(ctx, {
+				featurePermission: "ARCHIVE_WRITE_DOCUMENTS",
+			});
+			if (!hasPermission)
+				return Result.error(
+					new PermissionDeniedError(
+						"You do not have the permission required to perform this action.",
+					),
+				);
+
+			const schema = z.object({
+				name: z.string().min(1),
+			});
+			const validationResult = schema.safeParse(data);
+			if (!validationResult.success)
+				return Result.error(
+					new InvalidArgumentErrorV2("Invalid argument error", {
+						reason: validationResult.error.flatten().fieldErrors,
+						cause: validationResult.error,
+					}),
+				);
+
+			const createFileResult = await files.createFileUploadUrl(ctx, {
+				extension: data.fileExtension,
+			});
+			if (!createFileResult.ok) {
+				switch (createFileResult.error.name) {
+					case "DownstreamServiceError":
+						ctx.log.error(
+							createFileResult.error,
+							"Error creating file upload url",
+						);
+						return Result.error(
+							new DownstreamServiceError(
+								"Error creating file upload url",
+								createFileResult.error,
+							),
+						);
+					case "InternalServerError":
+						return Result.error(
+							new InternalServerError(
+								"Unexpected error when creating file",
+								createFileResult.error,
+							),
+						);
+					case "InvalidArgumentError":
+						return Result.error(
+							new InvalidArgumentErrorV2(
+								createFileResult.error.message,
+								createFileResult.error,
+							),
+						);
+					case "UnauthorizedError":
+						return Result.error(createFileResult.error);
+				}
+			}
+
+			const { file, url } = createFileResult.data;
+
+			const createDocumentResult = await repository.documents.create(ctx, {
+				fileId: file.id,
+				name: data.name,
+			});
+
+			if (!createDocumentResult.ok)
+				return Result.error(
+					new InternalServerError(
+						"Unexpected error when creating document",
+						createDocumentResult.error,
+					),
+				);
+
+			return Result.success({
+				document: createDocumentResult.data.document,
+				uploadUrl: url,
+			});
+		},
+		async update(ctx, data) {
+			if (!ctx.user)
+				return Result.error(
+					new UnauthorizedError(
+						"You must be logged in to perform this action.",
+					),
+				);
+			const hasPermission = await permissions.hasFeaturePermission(ctx, {
+				featurePermission: "ARCHIVE_WRITE_DOCUMENTS",
+			});
+			if (!hasPermission)
+				return Result.error(
+					new PermissionDeniedError(
+						"You do not have the permission required to perform this action.",
+					),
+				);
+			return Result.error(new InternalServerError("Not yet implemented"));
+		},
+		async delete(ctx, data) {
+			if (!ctx.user)
+				return Result.error(
+					new UnauthorizedError(
+						"You must be logged in to perform this action.",
+					),
+				);
+			const hasPermission = await permissions.hasFeaturePermission(ctx, {
+				featurePermission: "ARCHIVE_WRITE_DOCUMENTS",
+			});
+			if (!hasPermission)
+				return Result.error(
+					new PermissionDeniedError(
+						"You do not have the permission required to perform this action.",
+					),
+				);
+			return Result.error(new InternalServerError("Not yet implemented"));
+		},
+		async findMany(ctx) {
+			if (!ctx.user)
+				return Result.error(
+					new UnauthorizedError(
+						"You must be logged in to perform this action.",
+					),
+				);
+			const hasPermission = await permissions.hasFeaturePermission(ctx, {
+				featurePermission: "ARCHIVE_VIEW_DOCUMENTS",
+			});
+			if (!hasPermission)
+				return Result.error(
+					new PermissionDeniedError(
+						"You do not have the permission required to perform this action.",
+					),
+				);
+			return Result.error(new InternalServerError("Not yet implemented"));
+		},
+	};
+}
+
+export { buildDocuments };
+export type {
+	DocumentDependencies,
+	DocumentRepositoryType,
+	FileService,
+	PermissionService,
+};

--- a/src/services/documents/documents.ts
+++ b/src/services/documents/documents.ts
@@ -1,4 +1,4 @@
-import type { FeaturePermission } from "@prisma/client";
+import type { DocumentCategory, FeaturePermission } from "@prisma/client";
 import { z } from "zod";
 import type { Document, DocumentService } from "~/domain/documents.js";
 import {
@@ -17,7 +17,11 @@ type DocumentRepositoryType = {
 	documents: {
 		create(
 			ctx: Context,
-			data: Pick<Document, "fileId" | "name">,
+			data: Pick<Document, "fileId" | "name"> &
+				Partial<Pick<Document, "description">> &
+				Partial<{
+					categories: Pick<DocumentCategory, "name">[];
+				}>,
 		): ResultAsync<{ document: Document }, InternalServerError>;
 		update(
 			ctx: Context,

--- a/src/services/documents/documents.ts
+++ b/src/services/documents/documents.ts
@@ -39,6 +39,7 @@ type DocumentRepositoryType = {
 		>;
 		findMany(
 			ctx: Context,
+			by?: { categories?: { id: string }[] },
 		): ResultAsync<
 			{ documents: Document[]; total: number },
 			InternalServerError
@@ -198,7 +199,7 @@ function buildDocuments({
 				);
 			return Result.error(new InternalServerError("Not yet implemented"));
 		},
-		async findMany(ctx) {
+		async findMany(ctx, by) {
 			if (!ctx.user)
 				return Result.error(
 					new UnauthorizedError(
@@ -214,7 +215,9 @@ function buildDocuments({
 						"You do not have the permission required to perform this action.",
 					),
 				);
-			return await repository.documents.findMany(ctx);
+			return await repository.documents.findMany(ctx, {
+				categories: by?.categories ?? undefined,
+			});
 		},
 	};
 }

--- a/src/services/documents/documents.ts
+++ b/src/services/documents/documents.ts
@@ -158,7 +158,7 @@ function buildDocuments({
 				uploadUrl: url,
 			});
 		},
-		async update(ctx, data) {
+		async update(ctx, _data) {
 			if (!ctx.user)
 				return Result.error(
 					new UnauthorizedError(
@@ -176,7 +176,7 @@ function buildDocuments({
 				);
 			return Result.error(new InternalServerError("Not yet implemented"));
 		},
-		async delete(ctx, data) {
+		async delete(ctx, _data) {
 			if (!ctx.user)
 				return Result.error(
 					new UnauthorizedError(
@@ -210,7 +210,7 @@ function buildDocuments({
 						"You do not have the permission required to perform this action.",
 					),
 				);
-			return Result.error(new InternalServerError("Not yet implemented"));
+			return await repository.documents.findMany(ctx);
 		},
 	};
 }

--- a/src/services/documents/documents.ts
+++ b/src/services/documents/documents.ts
@@ -6,6 +6,7 @@ import {
 	InternalServerError,
 	type InvalidArgumentError,
 	InvalidArgumentErrorV2,
+	type NotFoundError,
 	PermissionDeniedError,
 	UnauthorizedError,
 } from "~/domain/errors.js";
@@ -25,18 +26,16 @@ type DocumentRepositoryType = {
 		): ResultAsync<{ document: Document }, InternalServerError>;
 		update(
 			ctx: Context,
-			data: Document,
-		): ResultAsync<
-			{ document: Document },
-			InvalidArgumentErrorV2 | InternalServerError
-		>;
+			data: Pick<Document, "id"> &
+				Partial<Pick<Document, "description" | "name">> &
+				Partial<{
+					categories: Pick<DocumentCategory, "name">[];
+				}>,
+		): ResultAsync<{ document: Document }, NotFoundError | InternalServerError>;
 		delete(
 			ctx: Context,
 			data: Pick<Document, "id">,
-		): ResultAsync<
-			{ document: Document },
-			InvalidArgumentErrorV2 | InternalServerError
-		>;
+		): ResultAsync<{ document: Document }, NotFoundError | InternalServerError>;
 		findMany(
 			ctx: Context,
 			by?: { categories?: { id: string }[] },

--- a/src/services/documents/documents.unit.test.ts
+++ b/src/services/documents/documents.unit.test.ts
@@ -1,0 +1,329 @@
+import { faker } from "@faker-js/faker";
+import { mockDeep } from "jest-mock-extended";
+import {
+	DownstreamServiceError,
+	InternalServerError,
+	InvalidArgumentError,
+	InvalidArgumentErrorV2,
+	PermissionDeniedError,
+	UnauthorizedError,
+} from "~/domain/errors.js";
+import { makeMockContext } from "~/lib/context.js";
+import { Result } from "~/lib/result.js";
+import {
+	type DocumentRepositoryType,
+	type FileService,
+	type PermissionService,
+	buildDocuments,
+} from "./documents.js";
+
+describe("Documents service", () => {
+	describe("#create", () => {
+		it("returns UnauthorizedError if the user is not authenticated", async () => {
+			const { service } = makeDependencies();
+
+			const result = await service.create(makeMockContext(null), {
+				name: faker.word.adjective(),
+				fileExtension: faker.string.uuid(),
+			});
+
+			expect(result).toEqual(Result.error(expect.any(UnauthorizedError)));
+		});
+
+		it("returns PermissionDeniedError if the user does not have permission", async () => {
+			const { service, permissions } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(false);
+
+			const result = await service.create(
+				makeMockContext({ id: faker.string.uuid() }),
+				{
+					name: faker.word.adjective(),
+					fileExtension: faker.string.uuid(),
+				},
+			);
+
+			expect(result).toEqual(Result.error(expect.any(PermissionDeniedError)));
+		});
+
+		it("requires ARCHIVE_WRITE_DOCUMENTS permission", async () => {
+			const { service, permissions } = makeDependencies();
+			const ctx = makeMockContext({ id: faker.string.uuid() });
+			await service.create(ctx, {
+				name: faker.word.adjective(),
+				fileExtension: faker.string.uuid(),
+			});
+
+			expect(permissions.hasFeaturePermission).toHaveBeenCalledWith(ctx, {
+				featurePermission: "ARCHIVE_WRITE_DOCUMENTS",
+			});
+		});
+
+		it("returns InvalidArugmentError if name is empty", async () => {
+			const { service, permissions } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(true);
+			const result = await service.create(
+				makeMockContext({ id: faker.string.uuid() }),
+				{
+					name: "",
+					fileExtension: faker.string.uuid(),
+				},
+			);
+			expect(result).toEqual(Result.error(expect.any(InvalidArgumentErrorV2)));
+		});
+
+		it("returns DownstreamServiceError file service returns DownstreamServiceError", async () => {
+			const { service, permissions, files } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(true);
+			files.createFileUploadUrl.mockResolvedValueOnce(
+				Result.error(
+					new DownstreamServiceError("Error creating file upload url"),
+				),
+			);
+			const result = await service.create(
+				makeMockContext({ id: faker.string.uuid() }),
+				{
+					name: faker.word.adjective(),
+					fileExtension: faker.string.uuid(),
+				},
+			);
+			expect(result).toEqual(Result.error(expect.any(DownstreamServiceError)));
+		});
+
+		it("returns InternalServerError file service returns InternalServerError", async () => {
+			const { service, permissions, files } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(true);
+			files.createFileUploadUrl.mockResolvedValueOnce(
+				Result.error(new InternalServerError("Error creating file upload url")),
+			);
+			const result = await service.create(
+				makeMockContext({ id: faker.string.uuid() }),
+				{
+					name: faker.word.adjective(),
+					fileExtension: faker.string.uuid(),
+				},
+			);
+			expect(result).toEqual(Result.error(expect.any(InternalServerError)));
+		});
+
+		it("returns InvalidArgumentErrorV2 file service returns InvalidArgumentError", async () => {
+			const { service, permissions, files } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(true);
+			files.createFileUploadUrl.mockResolvedValueOnce(
+				Result.error(
+					new InvalidArgumentError("Error creating file upload url"),
+				),
+			);
+			const result = await service.create(
+				makeMockContext({ id: faker.string.uuid() }),
+				{
+					name: faker.word.adjective(),
+					fileExtension: faker.string.uuid(),
+				},
+			);
+			expect(result).toEqual(Result.error(expect.any(InvalidArgumentErrorV2)));
+		});
+
+		it("returns UnauthorizedError file service returns UnauthorizedError", async () => {
+			const { service, permissions, files } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(true);
+			files.createFileUploadUrl.mockResolvedValueOnce(
+				Result.error(new UnauthorizedError("unauthorized")),
+			);
+			const result = await service.create(
+				makeMockContext({ id: faker.string.uuid() }),
+				{
+					name: faker.word.adjective(),
+					fileExtension: faker.string.uuid(),
+				},
+			);
+			expect(result).toEqual(Result.error(expect.any(UnauthorizedError)));
+		});
+
+		it("returns InternalServerError if repository returns InternalServerError", async () => {
+			const { service, permissions, files, repository } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(true);
+			files.createFileUploadUrl.mockResolvedValueOnce(
+				Result.success({
+					file: {
+						id: faker.string.uuid(),
+						name: faker.system.fileName(),
+						userId: faker.string.uuid(),
+					},
+					url: faker.internet.url(),
+				}),
+			);
+			repository.documents.create.mockResolvedValueOnce(
+				Result.error(new InternalServerError("Error creating document")),
+			);
+
+			const result = await service.create(
+				makeMockContext({ id: faker.string.uuid() }),
+				{
+					name: faker.word.adjective(),
+					fileExtension: faker.string.uuid(),
+				},
+			);
+			expect(result).toEqual(Result.error(expect.any(InternalServerError)));
+		});
+
+		it("creates a new document and returns an upload URL", async () => {
+			const { service, permissions, files, repository } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(true);
+			files.createFileUploadUrl.mockResolvedValueOnce(
+				Result.success({
+					file: {
+						id: faker.string.uuid(),
+						name: faker.system.fileName(),
+						userId: faker.string.uuid(),
+					},
+					url: faker.internet.url(),
+				}),
+			);
+			repository.documents.create.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					document: {
+						createdAt: new Date(),
+						fileId: faker.string.uuid(),
+						id: faker.string.uuid(),
+						name: faker.word.adjective(),
+						updatedAt: new Date(),
+					},
+				},
+			});
+
+			const result = await service.create(
+				makeMockContext({ id: faker.string.uuid() }),
+				{
+					name: faker.word.adjective(),
+					fileExtension: faker.string.uuid(),
+				},
+			);
+			expect(result).toEqual(
+				Result.success({
+					document: expect.objectContaining({
+						id: expect.any(String),
+					}),
+					uploadUrl: expect.any(String),
+				}),
+			);
+		});
+	});
+
+	describe("#update", () => {
+		it("returns UnauthorizedError if the user is not authenticated", async () => {
+			const { service } = makeDependencies();
+
+			const result = await service.update(makeMockContext(null), {
+				id: faker.string.uuid(),
+				name: faker.word.adjective(),
+			});
+
+			expect(result).toEqual(Result.error(expect.any(UnauthorizedError)));
+		});
+
+		it("returns PermissionDeniedError if the user does not have permission", async () => {
+			const { service, permissions } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(false);
+
+			const result = await service.update(
+				makeMockContext({ id: faker.string.uuid() }),
+				{
+					name: faker.word.adjective(),
+					id: faker.string.uuid(),
+				},
+			);
+
+			expect(result).toEqual(Result.error(expect.any(PermissionDeniedError)));
+		});
+
+		it("requires ARCHIVE_WRITE_DOCUMENTS permission", async () => {
+			const { service, permissions } = makeDependencies();
+			const ctx = makeMockContext({ id: faker.string.uuid() });
+			await service.update(ctx, {
+				id: faker.string.uuid(),
+				name: faker.word.adjective(),
+			});
+
+			expect(permissions.hasFeaturePermission).toHaveBeenCalledWith(ctx, {
+				featurePermission: "ARCHIVE_WRITE_DOCUMENTS",
+			});
+		});
+	});
+
+	describe("#delete", () => {
+		it("returns UnauthorizedError if the user is not authenticated", async () => {
+			const { service } = makeDependencies();
+
+			const result = await service.delete(makeMockContext(null), {
+				id: faker.string.uuid(),
+			});
+
+			expect(result).toEqual(Result.error(expect.any(UnauthorizedError)));
+		});
+
+		it("returns PermissionDeniedError if the user does not have permission", async () => {
+			const { service, permissions } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(false);
+
+			const result = await service.findMany(
+				makeMockContext({ id: faker.string.uuid() }),
+			);
+
+			expect(result).toEqual(Result.error(expect.any(PermissionDeniedError)));
+		});
+
+		it("requires ARCHIVE_WRITE_DOCUMENTS permission", async () => {
+			const { service, permissions } = makeDependencies();
+			const ctx = makeMockContext({ id: faker.string.uuid() });
+			await service.delete(ctx, { id: faker.string.uuid() });
+
+			expect(permissions.hasFeaturePermission).toHaveBeenCalledWith(ctx, {
+				featurePermission: "ARCHIVE_WRITE_DOCUMENTS",
+			});
+		});
+	});
+
+	describe("#findMany", () => {
+		it("returns UnauthorizedError if the user is not authenticated", async () => {
+			const { service } = makeDependencies();
+
+			const result = await service.findMany(makeMockContext(null));
+
+			expect(result).toEqual(Result.error(expect.any(UnauthorizedError)));
+		});
+
+		it("returns PermissionDeniedError if the user does not have permission", async () => {
+			const { service, permissions } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(false);
+
+			const result = await service.create(
+				makeMockContext({ id: faker.string.uuid() }),
+				{
+					name: faker.word.adjective(),
+					fileExtension: faker.string.uuid(),
+				},
+			);
+
+			expect(result).toEqual(Result.error(expect.any(PermissionDeniedError)));
+		});
+
+		it("requires ARCHIVE_VIEW_DOCUMENTS permission", async () => {
+			const { service, permissions } = makeDependencies();
+			const ctx = makeMockContext({ id: faker.string.uuid() });
+			await service.findMany(ctx);
+
+			expect(permissions.hasFeaturePermission).toHaveBeenCalledWith(ctx, {
+				featurePermission: "ARCHIVE_VIEW_DOCUMENTS",
+			});
+		});
+	});
+});
+
+function makeDependencies() {
+	const repository = mockDeep<DocumentRepositoryType>();
+	const permissions = mockDeep<PermissionService>();
+	const files = mockDeep<FileService>();
+	const service = buildDocuments({ repository, permissions, files });
+	return { repository, permissions, files, service };
+}

--- a/src/services/documents/documents.unit.test.ts
+++ b/src/services/documents/documents.unit.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { mockDeep } from "jest-mock-extended";
+import { Document } from "~/domain/documents.js";
 import {
 	DownstreamServiceError,
 	InternalServerError,
@@ -182,13 +183,7 @@ describe("Documents service", () => {
 			repository.documents.create.mockResolvedValueOnce({
 				ok: true,
 				data: {
-					document: {
-						createdAt: new Date(),
-						fileId: faker.string.uuid(),
-						id: faker.string.uuid(),
-						name: faker.word.adjective(),
-						updatedAt: new Date(),
-					},
+					document: makeDocument(),
 				},
 			});
 
@@ -323,15 +318,7 @@ describe("Documents service", () => {
 			permissions.hasFeaturePermission.mockResolvedValueOnce(true);
 			repository.documents.findMany.mockResolvedValueOnce(
 				Result.success({
-					documents: [
-						{
-							createdAt: new Date(),
-							fileId: faker.string.uuid(),
-							id: faker.string.uuid(),
-							name: faker.word.adjective(),
-							updatedAt: new Date(),
-						},
-					],
+					documents: [makeDocument()],
 					total: 1,
 				}),
 			);
@@ -353,6 +340,16 @@ describe("Documents service", () => {
 		});
 	});
 });
+
+function makeDocument(): Document {
+	return new Document({
+		id: faker.string.uuid(),
+		name: faker.word.adjective(),
+		fileId: faker.string.uuid(),
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	});
+}
 
 function makeDependencies() {
 	const repository = mockDeep<DocumentRepositoryType>();

--- a/src/services/documents/documents.unit.test.ts
+++ b/src/services/documents/documents.unit.test.ts
@@ -317,6 +317,40 @@ describe("Documents service", () => {
 				featurePermission: "ARCHIVE_VIEW_DOCUMENTS",
 			});
 		});
+
+		it("returns documents and the total count", async () => {
+			const { service, permissions, repository } = makeDependencies();
+			permissions.hasFeaturePermission.mockResolvedValueOnce(true);
+			repository.documents.findMany.mockResolvedValueOnce(
+				Result.success({
+					documents: [
+						{
+							createdAt: new Date(),
+							fileId: faker.string.uuid(),
+							id: faker.string.uuid(),
+							name: faker.word.adjective(),
+							updatedAt: new Date(),
+						},
+					],
+					total: 1,
+				}),
+			);
+
+			const result = await service.findMany(
+				makeMockContext({ id: faker.string.uuid() }),
+			);
+
+			expect(result).toEqual(
+				Result.success({
+					documents: expect.arrayContaining([
+						expect.objectContaining({
+							id: expect.any(String),
+						}),
+					]),
+					total: expect.any(Number),
+				}),
+			);
+		});
 	});
 });
 

--- a/src/services/documents/index.ts
+++ b/src/services/documents/index.ts
@@ -1,0 +1,2 @@
+export { DocumentService } from "./service.js";
+export type { DocumentRepositoryType } from "./documents.js";

--- a/src/services/documents/service.ts
+++ b/src/services/documents/service.ts
@@ -1,0 +1,12 @@
+import type { DocumentService as DocumentServiceType } from "~/domain/documents.js";
+import { type DocumentDependencies, buildDocuments } from "./documents.js";
+
+type Dependencies = DocumentDependencies;
+
+function DocumentService(dependencies: Dependencies): DocumentServiceType {
+	return {
+		documents: buildDocuments(dependencies),
+	};
+}
+
+export { DocumentService };


### PR DESCRIPTION
### Changes
- [FEATURE] Add documents support with service, repo, and GraphQL
- [FEATURE] Handle remote uploads by providing an upload url after creation
- [CHORE] Add tests
- [REFACTOR] Remove outdated `GoogleDocument` from schema
- [FEATURE]: Create, update, delete, and find many documents
- [FEATURE]: Find many by document category
- [CHORE]: Add document seeds