### PR TITLE
chore: include all @prisma packages in prisma dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       # All prisma packages should be updated together
       prisma:
         patterns:
-          - "@prisma/client*"
+          - "@prisma/*"
           - "prisma*"
       bull-board:
         patterns:


### PR DESCRIPTION
### Changes
- Include all `@prisma/` packages in the dependency group for dependabot

### Motivation
- Ensure all prisma dependencies are kept in sync