### PR TITLE
✨ feat(organizations): add color scheme, change member role

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:lts
+FROM node:lts
 WORKDIR /usr/src/app
 
 ENV PNPM_HOME="/pnpm"

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:lts-slim AS base
+FROM node:lts-slim AS base
 WORKDIR /usr/src/app
 
 LABEL org.opencontainers.image.source https://github.com/rubberdok/indok-api

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -269,6 +269,7 @@ model Organization {
   description String   @default("")
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+  colorScheme String?
 
   events             Event[]
   members            Member[]

--- a/schema.graphql
+++ b/schema.graphql
@@ -270,6 +270,11 @@ type CreateOrderResponse {
 }
 
 input CreateOrganizationInput {
+  """
+  The primary color (hex) for the organization, for example: #FF0000 for red.
+  """
+  colorScheme: String
+
   """The description of the organization, cannot exceed 10 000 characters"""
   description: String
 
@@ -858,6 +863,9 @@ type Mutation {
   Passing null or omitting a value will leave the value unchanged.
   """
   updateOrganization(data: UpdateOrganizationInput!): UpdateOrganizationResponse!
+
+  """Change the role of a member in the organization"""
+  updateRole(data: UpdateRoleInput!): UpdateRoleResponse!
   updateUser(data: UpdateUserInput!): UpdateUserResponse!
   uploadFile(data: UploadFileInput!): UploadFileResponse!
 }
@@ -969,6 +977,10 @@ type OrdersResponse {
 }
 
 type Organization {
+  """
+  The primary color (hex) for the organization, for example: #FF0000 for red.
+  """
+  colorScheme: String
   description: String!
   events: [Event!]!
 
@@ -1572,6 +1584,11 @@ type UpdateListingResponse {
 
 input UpdateOrganizationInput {
   """
+  The primary color (hex) for the organization, for example: #FF0000 for red.
+  """
+  colorScheme: String
+
+  """
   The new description of the organization, cannot exceed 10 000 characters
   Omitting the value or passing null will leave the description unchanged
   """
@@ -1596,6 +1613,18 @@ input UpdateOrganizationInput {
 
 type UpdateOrganizationResponse {
   organization: Organization!
+}
+
+input UpdateRoleInput {
+  """The ID of the member to change the role of"""
+  memberId: ID!
+
+  """The new role of the member"""
+  role: Role!
+}
+
+type UpdateRoleResponse {
+  member: Member!
 }
 
 input UpdateSlotInput {

--- a/src/domain/organizations.ts
+++ b/src/domain/organizations.ts
@@ -19,6 +19,7 @@ class Organization {
 	id: string;
 	name: string;
 	description: string;
+	colorScheme?: string | null;
 	logoFileId?: string | null;
 	featurePermissions: FeaturePermissionType[];
 
@@ -28,6 +29,7 @@ class Organization {
 		this.description = params.description;
 		this.logoFileId = params.logoFileId;
 		this.featurePermissions = params.featurePermissions;
+		this.colorScheme = params.colorScheme;
 	}
 }
 

--- a/src/graphql/organizations/resolvers/Mutation/createOrganization.ts
+++ b/src/graphql/organizations/resolvers/Mutation/createOrganization.ts
@@ -2,7 +2,7 @@ import type { MutationResolvers } from "./../../../types.generated.js";
 export const createOrganization: NonNullable<
 	MutationResolvers["createOrganization"]
 > = async (_parent, { data }, ctx) => {
-	const { name, description, featurePermissions } = data;
+	const { name, description, featurePermissions, colorScheme } = data;
 	ctx.log.info(
 		{ name, description, featurePermissions },
 		"Creating organization",
@@ -11,6 +11,7 @@ export const createOrganization: NonNullable<
 		name,
 		description,
 		featurePermissions,
+		colorScheme,
 	});
 	return {
 		organization,

--- a/src/graphql/organizations/resolvers/Mutation/updateOrganization.ts
+++ b/src/graphql/organizations/resolvers/Mutation/updateOrganization.ts
@@ -2,13 +2,15 @@ import type { MutationResolvers } from "./../../../types.generated.js";
 export const updateOrganization: NonNullable<
 	MutationResolvers["updateOrganization"]
 > = async (_parent, { data }, ctx) => {
-	const { id, name, description, featurePermissions, logoFileId } = data;
+	const { id, name, description, featurePermissions, logoFileId, colorScheme } =
+		data;
 
 	const organization = await ctx.organizations.organizations.update(ctx, id, {
 		name,
 		description,
 		featurePermissions,
 		logoFileId,
+		colorScheme,
 	});
 	return { organization };
 };

--- a/src/graphql/organizations/resolvers/Mutation/updateRole.ts
+++ b/src/graphql/organizations/resolvers/Mutation/updateRole.ts
@@ -1,0 +1,16 @@
+import type { MutationResolvers } from "./../../../types.generated.js";
+export const updateRole: NonNullable<MutationResolvers["updateRole"]> = async (
+	_parent,
+	{ data },
+	ctx,
+) => {
+	const result = await ctx.organizations.members.updateRole(ctx, {
+		memberId: data.memberId,
+		newRole: data.role,
+	});
+
+	if (!result.ok) {
+		throw result.error;
+	}
+	return result.data;
+};

--- a/src/graphql/organizations/resolvers/Mutation/updateRole.unit.test.ts
+++ b/src/graphql/organizations/resolvers/Mutation/updateRole.unit.test.ts
@@ -1,0 +1,84 @@
+import { faker } from "@faker-js/faker";
+import { InternalServerError } from "~/domain/errors.js";
+import {
+	OrganizationMember,
+	OrganizationRole,
+} from "~/domain/organizations.js";
+import { createMockApolloServer } from "~/graphql/test-clients/mock-apollo-server.js";
+import { graphql } from "~/graphql/test-clients/unit/gql.js";
+import { Result } from "~/lib/result.js";
+
+describe("Organiation mutations", () => {
+	describe("updateRole", () => {
+		it("updates a role", async () => {
+			const { client, organizationService } = createMockApolloServer();
+
+			organizationService.members.updateRole.mockResolvedValue({
+				ok: true,
+				data: {
+					member: new OrganizationMember({
+						id: faker.string.uuid(),
+						role: OrganizationRole.ADMIN,
+						organizationId: faker.string.uuid(),
+						userId: faker.string.uuid(),
+					}),
+				},
+			});
+
+			const { errors, data } = await client.mutate({
+				mutation: graphql(`
+        mutation UpdateRole($data: UpdateRoleInput!) {
+          updateRole(data: $data) {
+            member {
+              id
+            }
+          }
+        }
+          `),
+				variables: {
+					data: {
+						memberId: faker.string.uuid(),
+						role: OrganizationRole.ADMIN,
+					},
+				},
+			});
+
+			expect(errors).toBeUndefined();
+			expect(data).toEqual({
+				updateRole: {
+					member: {
+						id: expect.any(String),
+					},
+				},
+			});
+		});
+
+		it("throws on error", async () => {
+			const { client, organizationService } = createMockApolloServer();
+
+			organizationService.members.updateRole.mockResolvedValue(
+				Result.error(new InternalServerError("")),
+			);
+
+			const { errors } = await client.mutate({
+				mutation: graphql(`
+        mutation UpdateRole($data: UpdateRoleInput!) {
+          updateRole(data: $data) {
+            member {
+              id
+            }
+          }
+        }
+          `),
+				variables: {
+					data: {
+						memberId: faker.string.uuid(),
+						role: OrganizationRole.ADMIN,
+					},
+				},
+			});
+
+			expect(errors).toBeDefined();
+		});
+	});
+});

--- a/src/graphql/organizations/resolvers/UpdateRoleResponse.ts
+++ b/src/graphql/organizations/resolvers/UpdateRoleResponse.ts
@@ -1,0 +1,4 @@
+import type { UpdateRoleResponseResolvers } from "./../../types.generated.js";
+export const UpdateRoleResponse: UpdateRoleResponseResolvers = {
+	/* Implement UpdateRoleResponse resolver logic here */
+};

--- a/src/graphql/organizations/schema.graphql
+++ b/src/graphql/organizations/schema.graphql
@@ -34,6 +34,11 @@ type Mutation {
   Remove a member from the organization by the ID of the membership.
   """
   removeMember(data: RemoveMemberInput!): RemoveMemberResponse!
+
+  """
+  Change the role of a member in the organization
+  """
+  updateRole(data: UpdateRoleInput!): UpdateRoleResponse!
 }
 
 type Organization {
@@ -52,6 +57,10 @@ type Organization {
   events: [Event!]!
   listings: [Listing!]!
   logo: RemoteFile
+  """
+  The primary color (hex) for the organization, for example: #FF0000 for red.
+  """
+  colorScheme: String
 }
 
 type Member {
@@ -86,6 +95,21 @@ enum Role {
   MEMBER
 }
 
+input UpdateRoleInput {
+    """
+    The ID of the member to change the role of
+    """
+    memberId: ID!
+    """
+    The new role of the member
+    """
+    role: Role!
+}
+
+type UpdateRoleResponse {
+    member: Member!
+}
+
 input UpdateOrganizationInput {
   """
   The ID of the organization to update
@@ -107,6 +131,10 @@ input UpdateOrganizationInput {
   """
   featurePermissions: [FeaturePermission!]
   logoFileId: ID
+  """
+  The primary color (hex) for the organization, for example: #FF0000 for red.
+  """
+  colorScheme: String
 }
 
 type UpdateOrganizationResponse {
@@ -127,6 +155,10 @@ input CreateOrganizationInput {
   Requires that the current user is a super user, otherwise, this field is ignored.
   """
   featurePermissions: [FeaturePermission!]
+  """
+  The primary color (hex) for the organization, for example: #FF0000 for red.
+  """
+  colorScheme: String
 }
 
 type CreateOrganizationResponse {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -98,6 +98,7 @@ interface IOrganizationService {
 				name: string;
 				description?: string | null;
 				featurePermissions?: FeaturePermissionType[] | null;
+				colorScheme?: string | null;
 			},
 		): Promise<Organization>;
 		update(
@@ -108,6 +109,7 @@ interface IOrganizationService {
 				description: string | null;
 				featurePermissions: FeaturePermissionType[] | null;
 				logoFileId: string | null;
+				colorScheme: string | null;
 			}>,
 		): Promise<Organization>;
 		get(id: string): Promise<Organization>;
@@ -148,6 +150,17 @@ interface IOrganizationService {
 		): ResultAsync<
 			{ members: OrganizationMember[] },
 			PermissionDeniedError | UnauthorizedError
+		>;
+		updateRole(
+			ctx: Context,
+			params: { memberId: string; newRole: OrganizationRoleType },
+		): ResultAsync<
+			{ member: OrganizationMember },
+			| PermissionDeniedError
+			| UnauthorizedError
+			| InternalServerError
+			| InvalidArgumentErrorV2
+			| NotFoundError
 		>;
 	};
 	permissions: {

--- a/src/repositories/organizations/organizations.integration.test.ts
+++ b/src/repositories/organizations/organizations.integration.test.ts
@@ -7,7 +7,7 @@ import {
 	OrganizationRole,
 } from "~/domain/organizations.js";
 import prisma from "~/lib/prisma.js";
-import { OrganizationRepository } from "../../organizations.js";
+import { OrganizationRepository } from "./organizations.js";
 
 let organizationRepository: OrganizationRepository;
 

--- a/src/repositories/organizations/organizations.ts
+++ b/src/repositories/organizations/organizations.ts
@@ -35,6 +35,7 @@ export class OrganizationRepository {
 		description?: string;
 		userId: string;
 		featurePermissions?: FeaturePermission[];
+		colorScheme?: string;
 	}): Promise<Organization> {
 		const { userId, ...rest } = data;
 		return this.db.organization
@@ -74,14 +75,16 @@ export class OrganizationRepository {
 	 */
 	update(
 		id: string,
-		data: {
-			name?: string;
-			description?: string;
-			featurePermissions?: FeaturePermission[];
-			logoFileId?: string;
-		},
+		data: Partial<{
+			name: string;
+			description: string;
+			featurePermissions: FeaturePermission[];
+			logoFileId: string;
+			colorScheme: string;
+		}>,
 	): Promise<Organization> {
-		const { name, description, featurePermissions, logoFileId } = data;
+		const { name, description, featurePermissions, logoFileId, colorScheme } =
+			data;
 		return this.db.organization.update({
 			where: { id },
 			data: {
@@ -89,6 +92,7 @@ export class OrganizationRepository {
 				description,
 				featurePermissions,
 				logoFileId,
+				colorScheme,
 			},
 		});
 	}

--- a/src/services/organizations/__tests__/unit/organizations.test.ts
+++ b/src/services/organizations/__tests__/unit/organizations.test.ts
@@ -59,6 +59,7 @@ describe("OrganizationService", () => {
 					organizationId: string;
 					name?: string;
 					description?: string;
+					colorScheme?: string;
 				};
 				expectedError: unknown;
 			}[] = [
@@ -98,6 +99,18 @@ describe("OrganizationService", () => {
 					},
 					expectedError: expect.any(InvalidArgumentError),
 				},
+				{
+					name: "colorScheme is not a valid hex code",
+					state: {
+						user: mock<User>({ id: "1", isSuperUser: false }),
+						role: OrganizationRole.MEMBER,
+					},
+					input: {
+						organizationId: "o1",
+						colorScheme: "#gg0000",
+					},
+					expectedError: expect.any(InvalidArgumentError),
+				},
 			];
 
 			test.each(testCases)(
@@ -117,15 +130,12 @@ describe("OrganizationService", () => {
 					 * We call the update method with the user ID, organization ID, and the
 					 * new organization name.
 					 */
-					const { organizationId, name, description } = input;
+					const { organizationId, ...data } = input;
 					try {
 						await organizationService.organizations.update(
 							makeMockContext(state.user),
 							organizationId,
-							{
-								name,
-								description,
-							},
+							data,
 						);
 						fail("Expected to throw");
 					} catch (err) {
@@ -145,6 +155,7 @@ describe("OrganizationService", () => {
 					organizationId: string;
 					name?: string;
 					description?: string;
+					colorScheme?: string;
 				};
 			}[] = [
 				{
@@ -180,6 +191,16 @@ describe("OrganizationService", () => {
 						description: faker.company.catchPhrase(),
 					},
 				},
+				{
+					state: {
+						user: mock<User>({ id: "1", isSuperUser: true }),
+						role: null,
+					},
+					input: {
+						organizationId: "o1",
+						colorScheme: "#000",
+					},
+				},
 			];
 
 			test.each(testCases)(
@@ -199,11 +220,11 @@ describe("OrganizationService", () => {
 					 * We call the update method with the user ID, organization ID, and the
 					 * new organization name.
 					 */
-					const { organizationId, name, description } = input;
+					const { organizationId, ...data } = input;
 					const actual = organizationService.organizations.update(
 						makeMockContext(state.user),
 						organizationId,
-						{ name, description },
+						data,
 					);
 
 					/**
@@ -219,10 +240,7 @@ describe("OrganizationService", () => {
 					await expect(actual).resolves.not.toThrow();
 					expect(organizationRepository.update).toHaveBeenCalledWith(
 						input.organizationId,
-						{
-							name: input.name,
-							description: input.description,
-						},
+						data,
 					);
 				},
 			);
@@ -240,6 +258,7 @@ describe("OrganizationService", () => {
 					userId: string;
 					name: string;
 					description?: string;
+					colorScheme?: string;
 				};
 				expectedError: typeof KnownDomainError.name;
 			}[] = [
@@ -274,6 +293,18 @@ describe("OrganizationService", () => {
 					input: {
 						userId: "1",
 						name: "",
+					},
+					expectedError: InvalidArgumentError.name,
+				},
+				{
+					name: "colorScheme is not a valid color hex",
+					state: {
+						user: mock<User>({ id: "1", isSuperUser: false }),
+					},
+					input: {
+						userId: "1",
+						name: faker.company.name(),
+						colorScheme: "#fg0000",
 					},
 					expectedError: InvalidArgumentError.name,
 				},
@@ -320,6 +351,7 @@ describe("OrganizationService", () => {
 					userId: string;
 					name: string;
 					description?: string;
+					colorScheme?: string;
 				};
 			}[] = [
 				{
@@ -341,6 +373,17 @@ describe("OrganizationService", () => {
 						userId: "1",
 						name: faker.company.name(),
 						description: faker.company.catchPhrase(),
+					},
+				},
+				{
+					name: "with a valid color hex",
+					state: {
+						user: mock<User>({ id: "1", isSuperUser: false }),
+					},
+					input: {
+						userId: "1",
+						name: faker.company.name(),
+						colorScheme: "#000",
 					},
 				},
 			];

--- a/src/services/organizations/service.ts
+++ b/src/services/organizations/service.ts
@@ -23,6 +23,7 @@ interface OrganizationRepository {
 		description?: string;
 		userId: string;
 		featurePermissions?: FeaturePermissionType[];
+		colorScheme?: string;
 	}): Promise<Organization>;
 	update(
 		id: string,
@@ -31,6 +32,7 @@ interface OrganizationRepository {
 			description: string;
 			featurePermissions: FeaturePermissionType[];
 			logoFileId: string;
+			colorScheme: string;
 		}>,
 	): Promise<Organization>;
 	get(id: string): Promise<Organization>;
@@ -70,6 +72,16 @@ interface MemberRepository {
 		organizationId: string;
 		role: OrganizationRoleType;
 	}): Promise<boolean>;
+	updateRole(
+		ctx: Context,
+		data: {
+			memberId: string;
+			role: OrganizationRoleType;
+		},
+	): ResultAsync<
+		{ member: OrganizationMember },
+		InternalServerError | NotFoundError
+	>;
 }
 
 interface PermissionService {


### PR DESCRIPTION
### Changes
- Add color scheme to organizations, allowing them to select a color for themselves
- Add logic to update member roles in an organization, preventing updates to yourself to avoid putting yourself in a sticky situation where you demote yourself as the only admin.