### PR TITLE
:recycle: refactor: set user from session in fastify hook rather than apollo context

### DIFF
--- a/src/__tests__/integration/headers.test.ts
+++ b/src/__tests__/integration/headers.test.ts
@@ -1,0 +1,30 @@
+import type { FastifyInstance } from "fastify";
+import { env } from "~/config.js";
+import { fastifyServer } from "~/lib/fastify/fastify.js";
+import { registerServices } from "~/lib/server.js";
+
+describe("Headers", () => {
+	describe("GET /status", () => {
+		let server: FastifyInstance | undefined;
+
+		beforeAll(async () => {
+			const { serverInstance } = await fastifyServer(env);
+			server = serverInstance;
+			await registerServices(server);
+		});
+
+		it("sets transaction id header on the response", async () => {
+			const res = await server?.inject({
+				method: "GET",
+				url: "/status",
+				headers: { "x-transaction-id": "transaction-id" },
+			});
+			expect(res?.statusCode).toBe(200);
+			expect(res?.headers["x-transaction-id"]).toBe("transaction-id");
+		});
+
+		afterAll(async () => {
+			await server?.close();
+		});
+	});
+});

--- a/src/__tests__/integration/server.test.ts
+++ b/src/__tests__/integration/server.test.ts
@@ -18,8 +18,8 @@ describe("Server", () => {
 			expect(res?.statusCode).toBe(200);
 		});
 
-		afterAll(() => {
-			server?.close();
+		afterAll(async () => {
+			await server?.close();
 		});
 	});
 
@@ -38,8 +38,8 @@ describe("Server", () => {
 			expect(res.status).toBe(200);
 		});
 
-		afterAll(() => {
-			server?.close();
+		afterAll(async () => {
+			await server?.close();
 		});
 	});
 });

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -63,11 +63,6 @@ export const fastifyApolloSentryPlugin =
 								// Annotate whether failing operation was query/mutation/subscription
 								scope.setTag("kind", ctx.operation?.operation);
 
-								// Annotate with user ID
-								if (ctx.contextValue.user) {
-									scope.setUser({ id: ctx.contextValue.user.id });
-								}
-
 								// Log query and variables as extras
 								// (make sure to strip out sensitive data!)
 								scope.setExtra("query", ctx.request.query);

--- a/src/services/auth/plugin.ts
+++ b/src/services/auth/plugin.ts
@@ -1,264 +1,305 @@
 import type { FastifyPluginAsync } from "fastify";
+import fp from "fastify-plugin";
 import { env } from "~/config.js";
-import { BadRequestError, UnauthorizedError } from "~/domain/errors.js";
+import {
+	BadRequestError,
+	NotFoundError,
+	UnauthorizedError,
+} from "~/domain/errors.js";
+import type { User } from "~/domain/users.js";
 import { isValidRedirectUrl } from "~/utils/validate-redirect-url.js";
 
 const fastifyAuthPlugin: FastifyPluginAsync = (fastify) => {
-	fastify.route<{
-		Querystring: {
-			"return-to"?: string;
-		};
-	}>({
-		config: {
-			rateLimit: {
-				max: 100,
-				timeWindow: 60 * 1_000,
-			},
-		},
-		schema: {
-			querystring: {
-				type: "object",
-				properties: {
-					"return-to": { type: "string" },
-				},
-			},
-		},
-		url: "/login",
-		method: "GET",
-		handler: (req, reply) => {
-			const { "return-to": returnTo } = req.query;
-			const urlResult = fastify.services.auth.generateAuthorizationUrl(req, {
-				redirectUri: "/auth/login/callback",
-				returnTo,
-			});
-
-			if (!urlResult.ok) {
-				throw urlResult.error;
-			}
-
-			return reply.redirect(urlResult.data.authorizationUrl, 303);
-		},
-	});
-
-	fastify.route<{
-		Querystring: {
-			code: string;
-			state?: string;
-		};
-	}>({
-		config: {
-			rateLimit: {
-				max: 100,
-				timeWindow: 60 * 1_000,
-			},
-		},
-		url: "/login/callback",
-		method: "GET",
-		schema: {
-			querystring: {
-				type: "object",
-				properties: {
-					state: { type: "string" },
-					code: { type: "string" },
-				},
-				required: ["code"],
-			},
-		},
-		handler: async (req, reply) => {
-			const { code, state } = req.query;
-			let returnTo = env.CLIENT_URL;
-			if (state) {
-				const validationResult = isValidRedirectUrl(state);
-				if (validationResult.ok) {
-					returnTo = validationResult.data.urlAsString;
-				} else {
-					throw new BadRequestError(
-						"Invalid returnTo url",
-						validationResult.error,
-					);
-				}
-			}
-
-			const tokenResult = await fastify.services.auth.getAuthorizationToken(
-				req,
-				{
-					code,
-					redirectUri: "/auth/login/callback",
-				},
-			);
-
-			if (!tokenResult.ok) {
-				req.log.error(
-					{
-						error: tokenResult.error,
+	fastify.register(
+		async (instance) => {
+			instance.route<{
+				Querystring: {
+					"return-to"?: string;
+				};
+			}>({
+				config: {
+					rateLimit: {
+						max: 100,
+						timeWindow: 60 * 1_000,
 					},
-					"Failed to get authorization token",
-				);
-				switch (tokenResult.error.name) {
-					case "BadRequestError": {
-						throw new BadRequestError("Bad request", tokenResult.error);
-					}
-					default:
-						throw tokenResult.error;
-				}
-			}
-
-			const userInfoResult = await fastify.services.auth.getUserInfo(req, {
-				token: tokenResult.data.token,
-			});
-
-			if (!userInfoResult.ok) {
-				throw userInfoResult.error;
-			}
-
-			const getOrCreateUserResult = await fastify.services.auth.getOrCreateUser(
-				req,
-				{
-					userInfo: userInfoResult.data.userInfo,
 				},
-			);
-
-			if (!getOrCreateUserResult.ok) {
-				throw getOrCreateUserResult.error;
-			}
-
-			await fastify.services.auth.login(req, getOrCreateUserResult.data.user);
-
-			const updateStudyProgramResult =
-				await fastify.services.auth.updateStudyProgramForUser(req, {
-					token: tokenResult.data.token,
-				});
-			if (!updateStudyProgramResult.ok) {
-				await fastify.services.auth.logout(req);
-				req.log.error("Failed to update study program for user", {
-					error: updateStudyProgramResult.error,
-				});
-				throw updateStudyProgramResult.error;
-			}
-			return reply.redirect(returnTo, 303);
-		},
-	});
-
-	fastify.route<{
-		Querystring: {
-			code: string;
-			state?: string;
-		};
-	}>({
-		config: {
-			rateLimit: {
-				max: 100,
-				timeWindow: 60 * 1_000,
-			},
-		},
-		url: "/study-program/callback",
-		method: "GET",
-		schema: {
-			querystring: {
-				type: "object",
-				properties: {
-					code: { type: "string" },
-					state: { type: "string" },
+				schema: {
+					querystring: {
+						type: "object",
+						properties: {
+							"return-to": { type: "string" },
+						},
+					},
 				},
-				required: ["code"],
-			},
-		},
-		handler: async (req, reply) => {
-			const { code, state } = req.query;
-			let returnTo = env.CLIENT_URL;
-			if (state) {
-				const validationResult = isValidRedirectUrl(state);
-				if (validationResult.ok) {
-					returnTo = validationResult.data.urlAsString;
-				} else {
-					throw new BadRequestError(
-						"Invalid returnTo url",
-						validationResult.error,
+				url: "/login",
+				method: "GET",
+				handler: (req, reply) => {
+					const { "return-to": returnTo } = req.query;
+					const urlResult = instance.services.auth.generateAuthorizationUrl(
+						req,
+						{
+							redirectUri: "/auth/login/callback",
+							returnTo,
+						},
 					);
-				}
-			}
 
-			const tokenResult = await fastify.services.auth.getAuthorizationToken(
-				req,
-				{
-					code,
-					redirectUri: "/auth/study-program/callback",
+					if (!urlResult.ok) {
+						throw urlResult.error;
+					}
+
+					return reply.redirect(urlResult.data.authorizationUrl, 303);
 				},
-			);
-
-			if (!tokenResult.ok) {
-				throw tokenResult.error;
-			}
-
-			const updateStudyProgramResult =
-				await fastify.services.auth.updateStudyProgramForUser(req, {
-					token: tokenResult.data.token,
-				});
-
-			if (!updateStudyProgramResult.ok) {
-				throw updateStudyProgramResult.error;
-			}
-			return reply.redirect(returnTo, 303);
-		},
-	});
-
-	fastify.route<{
-		Querystring: {
-			"return-to"?: string;
-		};
-	}>({
-		config: {
-			rateLimit: {
-				max: 100,
-				timeWindow: 60 * 1_000,
-			},
-		},
-		schema: {
-			querystring: {
-				type: "object",
-				properties: {
-					"return-to": { type: "string" },
-				},
-			},
-		},
-		url: "/study-program",
-		method: "GET",
-		handler: (req, reply) => {
-			const { "return-to": returnTo } = req.query;
-			const urlResult = fastify.services.auth.generateAuthorizationUrl(req, {
-				redirectUri: "/auth/study-program/callback",
-				returnTo,
 			});
 
-			if (!urlResult.ok) {
-				throw urlResult.error;
+			instance.route<{
+				Querystring: {
+					code: string;
+					state?: string;
+				};
+			}>({
+				config: {
+					rateLimit: {
+						max: 100,
+						timeWindow: 60 * 1_000,
+					},
+				},
+				url: "/login/callback",
+				method: "GET",
+				schema: {
+					querystring: {
+						type: "object",
+						properties: {
+							state: { type: "string" },
+							code: { type: "string" },
+						},
+						required: ["code"],
+					},
+				},
+				handler: async (req, reply) => {
+					const { code, state } = req.query;
+					let returnTo = env.CLIENT_URL;
+					if (state) {
+						const validationResult = isValidRedirectUrl(state);
+						if (validationResult.ok) {
+							returnTo = validationResult.data.urlAsString;
+						} else {
+							throw new BadRequestError(
+								"Invalid returnTo url",
+								validationResult.error,
+							);
+						}
+					}
+
+					const tokenResult =
+						await instance.services.auth.getAuthorizationToken(req, {
+							code,
+							redirectUri: "/auth/login/callback",
+						});
+
+					if (!tokenResult.ok) {
+						req.log.error(
+							{
+								error: tokenResult.error,
+							},
+							"Failed to get authorization token",
+						);
+						switch (tokenResult.error.name) {
+							case "BadRequestError": {
+								throw new BadRequestError("Bad request", tokenResult.error);
+							}
+							default:
+								throw tokenResult.error;
+						}
+					}
+
+					const userInfoResult = await instance.services.auth.getUserInfo(req, {
+						token: tokenResult.data.token,
+					});
+
+					if (!userInfoResult.ok) {
+						throw userInfoResult.error;
+					}
+
+					const getOrCreateUserResult =
+						await instance.services.auth.getOrCreateUser(req, {
+							userInfo: userInfoResult.data.userInfo,
+						});
+
+					if (!getOrCreateUserResult.ok) {
+						throw getOrCreateUserResult.error;
+					}
+
+					await instance.services.auth.login(
+						req,
+						getOrCreateUserResult.data.user,
+					);
+
+					const updateStudyProgramResult =
+						await instance.services.auth.updateStudyProgramForUser(req, {
+							token: tokenResult.data.token,
+						});
+					if (!updateStudyProgramResult.ok) {
+						await instance.services.auth.logout(req);
+						req.log.error("Failed to update study program for user", {
+							error: updateStudyProgramResult.error,
+						});
+						throw updateStudyProgramResult.error;
+					}
+					return reply.redirect(returnTo, 303);
+				},
+			});
+
+			instance.route<{
+				Querystring: {
+					code: string;
+					state?: string;
+				};
+			}>({
+				config: {
+					rateLimit: {
+						max: 100,
+						timeWindow: 60 * 1_000,
+					},
+				},
+				url: "/study-program/callback",
+				method: "GET",
+				schema: {
+					querystring: {
+						type: "object",
+						properties: {
+							code: { type: "string" },
+							state: { type: "string" },
+						},
+						required: ["code"],
+					},
+				},
+				handler: async (req, reply) => {
+					const { code, state } = req.query;
+					let returnTo = env.CLIENT_URL;
+					if (state) {
+						const validationResult = isValidRedirectUrl(state);
+						if (validationResult.ok) {
+							returnTo = validationResult.data.urlAsString;
+						} else {
+							throw new BadRequestError(
+								"Invalid returnTo url",
+								validationResult.error,
+							);
+						}
+					}
+
+					const tokenResult =
+						await instance.services.auth.getAuthorizationToken(req, {
+							code,
+							redirectUri: "/auth/study-program/callback",
+						});
+
+					if (!tokenResult.ok) {
+						throw tokenResult.error;
+					}
+
+					const updateStudyProgramResult =
+						await instance.services.auth.updateStudyProgramForUser(req, {
+							token: tokenResult.data.token,
+						});
+
+					if (!updateStudyProgramResult.ok) {
+						throw updateStudyProgramResult.error;
+					}
+					return reply.redirect(returnTo, 303);
+				},
+			});
+
+			instance.route<{
+				Querystring: {
+					"return-to"?: string;
+				};
+			}>({
+				config: {
+					rateLimit: {
+						max: 100,
+						timeWindow: 60 * 1_000,
+					},
+				},
+				schema: {
+					querystring: {
+						type: "object",
+						properties: {
+							"return-to": { type: "string" },
+						},
+					},
+				},
+				url: "/study-program",
+				method: "GET",
+				handler: (req, reply) => {
+					const { "return-to": returnTo } = req.query;
+					const urlResult = instance.services.auth.generateAuthorizationUrl(
+						req,
+						{
+							redirectUri: "/auth/study-program/callback",
+							returnTo,
+						},
+					);
+
+					if (!urlResult.ok) {
+						throw urlResult.error;
+					}
+
+					return reply.redirect(urlResult.data.authorizationUrl, 303);
+				},
+			});
+
+			instance.route({
+				method: "get",
+				url: "/logout",
+				handler: async (req, reply) => {
+					await instance.services.auth.logout(req);
+					req.log.info("User logged out");
+					return reply.redirect(env.CLIENT_URL, 303);
+				},
+			});
+
+			instance.route({
+				method: "GET",
+				url: "/me",
+				handler: (req, reply) => {
+					if (req.user) {
+						return reply.status(200).send({ user: req.user });
+					}
+					return reply.send(new UnauthorizedError("Unauthorized"));
+				},
+			});
+		},
+		{
+			prefix: "/auth",
+		},
+	);
+
+	fastify.addHook("preHandler", async (request) => {
+		const userId = request.session.get("userId");
+		request.log.info({ userId }, "User ID from session");
+		if (userId) {
+			try {
+				const user = await request.server.services.users.get(userId);
+				request.user = user;
+				return;
+			} catch (err) {
+				if (err instanceof NotFoundError) {
+					await request.server.services.auth.logout(request);
+				} else {
+					throw err;
+				}
 			}
-
-			return reply.redirect(urlResult.data.authorizationUrl, 303);
-		},
-	});
-
-	fastify.route({
-		method: "get",
-		url: "/logout",
-		handler: async (req, reply) => {
-			await fastify.services.auth.logout(req);
-			req.log.info("User logged out");
-			return reply.redirect(env.CLIENT_URL, 303);
-		},
-	});
-
-	fastify.route({
-		method: "GET",
-		url: "/me",
-		handler: (req, reply) => {
-			if (req.session.userId) {
-				return reply.status(200).send({ user: req.session.userId });
-			}
-			return reply.send(new UnauthorizedError("Unauthorized"));
-		},
+		}
+		request.user = null;
 	});
 	return Promise.resolve();
 };
 
-export default fastifyAuthPlugin;
+declare module "fastify" {
+	interface FastifyRequest {
+		user: User | null;
+	}
+}
+
+export default fp(fastifyAuthPlugin);

--- a/src/services/auth/plugin.ts
+++ b/src/services/auth/plugin.ts
@@ -1,4 +1,4 @@
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginAsync, RouteShorthandOptions } from "fastify";
 import fp from "fastify-plugin";
 import { env } from "~/config.js";
 import {
@@ -9,6 +9,13 @@ import {
 import type { User } from "~/domain/users.js";
 import { isValidRedirectUrl } from "~/utils/validate-redirect-url.js";
 
+const rateLimitConfig: RouteShorthandOptions["config"] = {
+	rateLimit: {
+		max: 100,
+		timeWindow: 60 * 1_000,
+	},
+};
+
 const fastifyAuthPlugin: FastifyPluginAsync = (fastify) => {
 	fastify.register(
 		async (instance) => {
@@ -17,12 +24,7 @@ const fastifyAuthPlugin: FastifyPluginAsync = (fastify) => {
 					"return-to"?: string;
 				};
 			}>({
-				config: {
-					rateLimit: {
-						max: 100,
-						timeWindow: 60 * 1_000,
-					},
-				},
+				config: rateLimitConfig,
 				schema: {
 					querystring: {
 						type: "object",
@@ -57,12 +59,7 @@ const fastifyAuthPlugin: FastifyPluginAsync = (fastify) => {
 					state?: string;
 				};
 			}>({
-				config: {
-					rateLimit: {
-						max: 100,
-						timeWindow: 60 * 1_000,
-					},
-				},
+				config: rateLimitConfig,
 				url: "/login/callback",
 				method: "GET",
 				schema: {
@@ -155,12 +152,7 @@ const fastifyAuthPlugin: FastifyPluginAsync = (fastify) => {
 					state?: string;
 				};
 			}>({
-				config: {
-					rateLimit: {
-						max: 100,
-						timeWindow: 60 * 1_000,
-					},
-				},
+				config: rateLimitConfig,
 				url: "/study-program/callback",
 				method: "GET",
 				schema: {
@@ -215,12 +207,7 @@ const fastifyAuthPlugin: FastifyPluginAsync = (fastify) => {
 					"return-to"?: string;
 				};
 			}>({
-				config: {
-					rateLimit: {
-						max: 100,
-						timeWindow: 60 * 1_000,
-					},
-				},
+				config: rateLimitConfig,
 				schema: {
 					querystring: {
 						type: "object",

--- a/src/services/auth/service.ts
+++ b/src/services/auth/service.ts
@@ -329,7 +329,7 @@ export class AuthService {
 	 * @returns
 	 */
 	async login(req: FastifyRequest, user: User): Promise<User> {
-		await req.session.regenerate([]);
+		await req.session.regenerate();
 		req.session.set("userId", user.id);
 		const updatedUser = await this.userService.login(user.id);
 		req.log.info({ userId: user.id }, "User logged in");
@@ -344,13 +344,8 @@ export class AuthService {
 	 * @returns
 	 */
 	async logout(req: FastifyRequest): Promise<void> {
-		if (req.session.get("userId")) {
-			await req.session.destroy();
-			return;
-		}
-		throw new UnauthorizedError(
-			"You need to be logged in to perform this action.",
-		);
+		await req.session.regenerate();
+		req.log.info({ userId: req.session.get("userId") }, "User logged out");
 	}
 }
 


### PR DESCRIPTION
### Changes
- Move user fetching to fastify hook rather than apollo context
- Set user to `req.user`
- Forward transaction ID from header and add it to Sentry
- Add test cases for the above changes